### PR TITLE
Add redirect_uri to github oauth param

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,6 +9,9 @@ GITHUB_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # openssl pkey -in /path/to/private-key.pem -outform der | openssl base64 -A
 GITHUB_PRIVATE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/about-the-user-authorization-callback-url
+GITHUB_OAUTH_REDIRECT_URI=http://localhost:3000/auth/github/callback
+
 
 SENTRY_DSN=https://xxxxxxxxxxxxxxxx.ingest.sentry.io/00000000000
 SENTRY_ENV=staging # or production (if not set, used Rails.env)

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :github, ENV["GITHUB_KEY"], ENV["GITHUB_SECRET"]
+  provider :github, ENV["GITHUB_KEY"], ENV["GITHUB_SECRET"], {
+    client_options: { redirect_uri: ENV["GITHUB_OAUTH_REDIRECT_URI"] }
+  }
 end


### PR DESCRIPTION
## why
> You can specify up to 10 callback URLs. If you specify multiple callback URLs, you can use the redirect_uri parameter when you prompt the user to authorize your GitHub App, to indicate which callback URL the user should be redirected to.
> https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/about-the-user-authorization-callback-url

We registered two callback URLs.

![image](https://github.com/kaigionrails/conference-app/assets/4487291/2a87058b-a307-4b4f-9efe-25467d12df80)
