### PR TITLE
Fix sigs for AuthenticationProviderGithub

### DIFF
--- a/sig/app/models/authentication_provider_github.rbs
+++ b/sig/app/models/authentication_provider_github.rbs
@@ -1,6 +1,6 @@
 
 class AuthenticationProviderGithub < ApplicationRecord
-  def self.find_or_create_user_from_auth_hash: (untyped auth) -> untyped
+  def self.find_or_create_user_from_auth_hash: (untyped auth) -> ::User
 
-  def self.create_user_from_auth_hash: (untyped auth) -> untyped
+  def self.create_user_from_auth_hash: (untyped auth) -> ::User
 end


### PR DESCRIPTION
`.create_user_from_auth_hash` returns `User` initialized in L12.
https://github.com/kaigionrails/conference-app/blob/0c8e1996f667001e3e7916f00cf9c3e0d1abf994/app/models/authentication_provider_github.rb#L11-L23

`.find_or_create_user_from_auth_hash` returns `authentication_provider_github.user` in L6 or the result of `.create_user_from_auth_hash`. So in any case, the return type is `User`.
https://github.com/kaigionrails/conference-app/blob/0c8e1996f667001e3e7916f00cf9c3e0d1abf994/app/models/authentication_provider_github.rb#L4-L9

```sh
$ bundle exec steep validate && bundle exec steep check                     
# Type checking files:

..............................................................................................................................................................................................................................

No type error detected. 🫖
```