### PR TITLE
Mark all annnounce to unread on create a new user

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,6 +6,7 @@ class SessionsController < ApplicationController
     if params[:provider] != "github"
       flash[:alert] = "Unknown provider"
       redirect_to login_path
+      return
     end
 
     user = AuthenticationProviderGithub.find_or_create_user_from_auth_hash(request.env["omniauth.auth"])

--- a/app/models/authentication_provider_github.rb
+++ b/app/models/authentication_provider_github.rb
@@ -19,6 +19,6 @@ class AuthenticationProviderGithub < ApplicationRecord
     end
     DetermineUserRoleJob.perform_later(user.id)
     profile.ensure_image_from_github
-    user
+    user.tap { user.mark_all_announcement_unread! }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,12 @@ class User < ApplicationRecord
   def have_unread_announcements?
     unread_announcements.exists?
   end
+
+  def mark_all_announcement_unread!(event = nil)
+    event ||= Event.find_by!(slug: Event::ONGOING_EVENT_SLUG)
+    insert_ary = Announcement.published.where(event: event).pluck(:id).map do |ann_id|
+      { announcement_id: ann_id, user_id: id }
+    end
+    UnreadAnnouncement.insert_all!(insert_ary) unless insert_ary.empty?
+  end
 end

--- a/spec/models/authentication_provider_github_spec.rb
+++ b/spec/models/authentication_provider_github_spec.rb
@@ -2,7 +2,10 @@ require 'rails_helper'
 
 RSpec.describe AuthenticationProviderGithub, type: :model do
   describe "self.create_user_from_auth_hash" do
+    let(:event) { FactoryBot.create(:event) }
     let(:auth_hash) { { "info" => { "nickname" => "octocat" }, "uid" => "583231"} } # https://github.com/octocat
+
+    before { Event::ONGOING_EVENT_SLUG = event.slug } # TODO: Fix this hack
 
     it "should success user and profile image from GitHub" do
       allow_any_instance_of(Profile).to receive(:fetch_profile_image_from_github).and_return(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { FactoryBot.create(:user) }
+
+  describe "#mark_all_announcement_unread!" do
+    context "there is no published announcement" do
+      let(:event) { FactoryBot.create(:event) }
+      let!(:announcements)  { FactoryBot.create_list(:announcement, 3, event: event) }
+      it "should not create any UnreadAnnouncement" do
+        expect { user.mark_all_announcement_unread!(event) }.not_to change { UnreadAnnouncement.where(user: user).count }
+      end
+    end
+
+    context "there is some published announcement" do
+      let(:event) { FactoryBot.create(:event) }
+      let!(:announcements_published)  { FactoryBot.create_list(:announcement, 3, :published, event: event) }
+      let!(:announcements_draft)  { FactoryBot.create_list(:announcement, 2, event: event) }
+      it "should create UnreadAnnouncement for number of published announcements" do
+        expect { user.mark_all_announcement_unread!(event) }.to change { UnreadAnnouncement.where(user: user).count }.by(3)
+      end
+    end
+
+    context "there is some published announcement but another event" do
+      let(:event1) { FactoryBot.create(:event) }
+      let(:event2) { FactoryBot.create(:event) }
+      let!(:announcements_published)  { FactoryBot.create_list(:announcement, 3, :published, event: event1) }
+      it "should create UnreadAnnouncement for number of published announcements" do
+        expect { user.mark_all_announcement_unread!(event2) }.not_to change { UnreadAnnouncement.where(user: user).count }
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,3 +66,5 @@ RSpec.configure do |config|
   config.include LoginHelper, type: :request
   config.include EventHelper, type: :request
 end
+
+OmniAuth.config.test_mode = true

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,18 +1,45 @@
 require 'rails_helper'
 
-RSpec.xdescribe "Sessions", type: :request do
-  describe "GET /create" do
-    it "returns http success" do
-      get "/sessions/create"
-      expect(response).to have_http_status(:success)
+RSpec.describe "Sessions", type: :request do
+  describe "GET /auth/:provider/callback" do
+    context "unknown provider" do
+      it "should redirect to /login" do
+        get "/auth/foobar/callback"
+        expect(response).to redirect_to(login_path)
+      end
+    end
+
+    context "provider is GitHub" do
+      context "exists user" do
+        let(:user) { FactoryBot.create(:user, name: "octocat") }
+        let(:authentication_provider_github) { FactoryBot.create(:authentication_provider_github, user: user) }
+        let!(:auth_uid) { authentication_provider_github.uid }
+
+        before do
+          OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
+            provider: :github,
+            uid: auth_uid
+          })
+        end
+
+        it "should redirect to root_path" do
+          get "/auth/github/callback"
+          expect(response).to redirect_to(root_path)
+          expect(session[:user_id]).to eq user.id
+        end
+      end
+
+      context "create new user" do
+        let(:auth_hash) { { "info" => { "nickname" => "octocat" }, "uid" => "583231"} } # https://github.com/octocat
+        before { OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(auth_hash) }
+
+        it "should create user, authentication_provider_github, profile and enqueue job" do
+          expect { get "/auth/github/callback" }.to change {
+            AuthenticationProviderGithub.count }.by(1).and change {
+              User.count
+            }.by(1).and change { Profile.count }.by(1).and have_enqueued_job(DetermineUserRoleJob)
+        end
+      end
     end
   end
-
-  describe "GET /destroy" do
-    it "returns http success" do
-      get "/sessions/destroy"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -42,9 +42,10 @@ RSpec.describe "Sessions", type: :request do
 
         it "should create user, authentication_provider_github, profile, unread_announcement and enqueue job" do
           expect { get "/auth/github/callback" }.to change {
-            AuthenticationProviderGithub.count }.by(1).and change {
-              User.count
-            }.by(1).and change { Profile.count }.by(1).and have_enqueued_job(DetermineUserRoleJob).and change {
+              AuthenticationProviderGithub.count }.by(1).and change {
+              User.count }.by(1).and change {
+              Profile.count }.by(1).and have_enqueued_job(
+              DetermineUserRoleJob).and change {
               UnreadAnnouncement.count }.by(1)
         end
       end


### PR DESCRIPTION
## why
We want to read all announcements to all participants.