### PR TITLE
Refactor: Move callback procedure to controller from model in AuthenticationProviderGithub

### DIFF
--- a/app/models/authentication_provider_github.rb
+++ b/app/models/authentication_provider_github.rb
@@ -1,18 +1,14 @@
 class AuthenticationProviderGithub < ApplicationRecord
   belongs_to :user
 
-  def self.find_or_create_user_from_auth_hash(auth, &block)
+  def self.find_or_create_user_from_auth_hash(auth, &)
     authentication_provider_github = AuthenticationProviderGithub.eager_load(:user).find_by(uid: auth.uid)
     return authentication_provider_github.user if authentication_provider_github
 
-    if block_given?
-      create_user_from_auth_hash(auth, &block)
-    else
-      create_user_from_auth_hash(auth)
-    end
+    create_user_from_auth_hash(auth, &)
   end
 
-  def self.create_user_from_auth_hash(auth)
+  def self.create_user_from_auth_hash(auth, &block)
     user = User.new(name: auth["info"]["nickname"], role: "participant")
     profile = Profile.new(user: user, name: user.name)
     auth_provider = AuthenticationProviderGithub.new(uid: auth["uid"], user: user)
@@ -21,7 +17,7 @@ class AuthenticationProviderGithub < ApplicationRecord
       auth_provider.save!
       profile.save!
     end
-    yield(user) if block_given?
+    yield(user) if block
     user
   end
 end

--- a/sig/handwritten/app/models/authentication_provider_github.rbs
+++ b/sig/handwritten/app/models/authentication_provider_github.rbs
@@ -1,5 +1,5 @@
 class AuthenticationProviderGithub < ApplicationRecord
-  def self.find_or_create_user_from_auth_hash: (untyped auth) -> ::User
+  def self.find_or_create_user_from_auth_hash: (untyped auth) ?{ (::User) -> untyped } -> ::User
 
-  def self.create_user_from_auth_hash: (untyped auth) -> ::User
+  def self.create_user_from_auth_hash: (untyped auth) ?{ (::User) -> untyped } -> ::User
 end

--- a/spec/models/authentication_provider_github_spec.rb
+++ b/spec/models/authentication_provider_github_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe AuthenticationProviderGithub, type: :model do
       }.to change { AuthenticationProviderGithub.count }.by(1).and change { User.count }.by(1).and change { Profile.count }.by(1)
       user = User.find_by!(name: "octocat")
       expect(user.profile.name).to eq "octocat"
-      expect(user.profile.images.size).to eq 1
     end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe "Sessions", type: :request do
         let(:auth_hash) { {"info" => {"nickname" => "octocat"}, "uid" => "583231"} } # https://github.com/octocat
 
         before do
-          allow_any_instance_of(Profile).to receive(:ensure_image_from_github).and_return(nil) # hmm....
           OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(auth_hash)
         end
 


### PR DESCRIPTION
## what
Move user-preparing methods from AuthenticationProviderGithub model