### PR TITLE
Fix announcements list background color

### DIFF
--- a/app/views/announcements/index.html.erb
+++ b/app/views/announcements/index.html.erb
@@ -1,6 +1,6 @@
 <div class="w-full max-w-screen-xl mx-auto md:my-auto pt-4 px-4">
   <h2 class="font-bold text-2xl mb-3">アナウンス一覧</h2>
-  <ol class="border rounded-lg">
+  <ol class="border rounded-lg pl-0">
     <% @announcements.each do |announcement| %>
       <li class="block">
         <%= link_to event_announcement_path(event_slug: @event.slug, id: announcement.id), class: "block py-4 px-2 md:px-4 flex flex-row items-center bg-white bg-opacity-0 hover:bg-opacity-20" do %>


### PR DESCRIPTION
## why
Fix this

<img width="375" alt="スクリーンショット 2023-10-27 11 52 50" src="https://github.com/kaigionrails/conference-app/assets/4487291/28e2e115-f6ae-43f6-a61a-6bce46a2d1a1">
