### PR TITLE
Remove unused stimulus file: hello_controller.js

### DIFF
--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus";
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!";
-  }
-}


### PR DESCRIPTION
Thank you for building this App ✨ 

While looking through the repository, I noticed that `controllers/hello_controller.rb` does not exist, so maybe we could remove `app/javascript/controllers/hello_controller.js`?