### PR TITLE
Always use double quotes in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,6 @@ group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
   gem "rbs", require: false
-  gem 'rbs_rails', require: false
+  gem "rbs_rails", require: false
   gem "steep", require: false
 end


### PR DESCRIPTION
There was one set of single quotes in Gemfile, so it was changed.

Actually, I wanted to implement a functionality, but building the development environment took so long and I gave up tonight...🥹