### PR TITLE
Add TOC of talks 

### DIFF
--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -2,8 +2,4 @@ module TalksHelper
   def time_with_zone_to_anchor(time_with_zone)
     time_with_zone.in_time_zone("Tokyo").strftime("%m%d-%H%M")
   end
-
-  def time_with_zone_to_header(time_with_zone)
-    time_with_zone.in_time_zone("Tokyo").strftime("%d日 %H:%M ～")
-  end
 end

--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -1,0 +1,9 @@
+module TalksHelper
+  def time_with_zone_to_anchor(time_with_zone)
+    time_with_zone.in_time_zone("Tokyo").strftime("%m%d-%H%M")
+  end
+
+  def time_with_zone_to_header(time_with_zone)
+    time_with_zone.in_time_zone("Tokyo").strftime("%d日 %H:%M ～")
+  end
+end

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -1,4 +1,21 @@
 <div class="w-full max-w-screen-xl m-auto pt-4 px-4">
+  <section class="mb-6">
+    <h2 class="font-bold text-2xl mb-3">TOC</h2>
+    <% @talks.map(&:start_at).uniq.group_by(&:to_date).each do |date, slots| %>
+      <details class="mb-3">
+        <summary>
+          <span class="font-bold text-xl mb-3 cursor-pointer"><%= date.to_s %></span>
+        </summary>
+        <ol class="list-disc pl-8">
+          <% slots.each do |slot| %>
+            <li>
+              <%= link_to time_with_zone_to_header(slot), "#" + time_with_zone_to_anchor(slot), class: "underline cursor-pointer" %>
+            </li>
+          <% end %>
+        </ol>
+      </details>
+    <% end %>
+  </section>
   <% @talks.group_by(&:start_at).each do |slot, talks| %>
     <section class="mb-6">
       <h2 class="font-bold text-2xl mb-3" id=<%= time_with_zone_to_anchor(slot) %>><%= time_with_zone_to_header(slot) %></h2>

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -9,7 +9,7 @@
         <ol class="list-disc pl-8">
           <% slots.each do |slot| %>
             <li>
-              <%= link_to time_with_zone_to_header(slot), "#" + time_with_zone_to_anchor(slot), class: "underline cursor-pointer" %>
+              <%= link_to slot.in_time_zone("Tokyo").strftime("%H:%M ～"), "#" + time_with_zone_to_anchor(slot), class: "underline cursor-pointer" %>
             </li>
           <% end %>
         </ol>
@@ -18,7 +18,7 @@
   </section>
   <% @talks.group_by(&:start_at).each do |slot, talks| %>
     <section class="mb-6">
-      <h2 class="font-bold text-2xl mb-3" id=<%= time_with_zone_to_anchor(slot) %>><%= time_with_zone_to_header(slot) %></h2>
+      <h2 class="font-bold text-2xl mb-3" id=<%= time_with_zone_to_anchor(slot) %>><%= slot.in_time_zone("Tokyo").strftime("%d日 %H:%M ～") %></h2>
       <section class="flex flex-row justify-between flex-wrap items-start">
         <% talks.each do |talk| %>
           <div class="w-full md:w-[48%] border border-white shadow-sm shadow-gray-400 rounded-lg mb-4 p-4">

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -4,7 +4,7 @@
     <% @talks.map(&:start_at).uniq.group_by(&:to_date).each do |date, slots| %>
       <details class="mb-3">
         <summary>
-          <span class="font-bold text-xl mb-3 cursor-pointer"><%= date.to_s %></span>
+          <span class="font-bold text-xl mb-3 cursor-pointer"><%= date.in_time_zone("Tokyo").strftime("%d日") %></span>
         </summary>
         <ol class="list-disc pl-8">
           <% slots.each do |slot| %>

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full max-w-screen-xl m-auto pt-4 px-4">
   <% @talks.group_by(&:start_at).each do |slot, talks| %>
     <section class="mb-6">
-      <h2 class="font-bold text-2xl mb-3"><%= slot.in_time_zone("Tokyo").strftime("%d日 %H:%M ～") %></h2>
+      <h2 class="font-bold text-2xl mb-3" id=<%= time_with_zone_to_anchor(slot) %>><%= time_with_zone_to_header(slot) %></h2>
       <section class="flex flex-row justify-between flex-wrap items-start">
         <% talks.each do |talk| %>
           <div class="w-full md:w-[48%] border border-white shadow-sm shadow-gray-400 rounded-lg mb-4 p-4">

--- a/spec/helpers/talks_helper_spec.rb
+++ b/spec/helpers/talks_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe TalksHelper, type: :helper do
+  describe "#time_with_zone_to_header" do
+    it "converts a TimeWithZone object to a header string" do
+      expect(helper.time_with_zone_to_header(Time.zone.parse('2023-10-27 12:34:56 JST +09:00'))).to eq("27日 12:34 ～")
+    end
+  end
+
+  describe "#time_with_zone_to_anchor" do
+    it "converts a TimeWithZone object to an anchor string" do
+      expect(helper.time_with_zone_to_anchor(Time.zone.parse('2023-10-27 12:34:56 JST +09:00'))).to eq("1027-1234")
+    end
+  end
+end

--- a/spec/helpers/talks_helper_spec.rb
+++ b/spec/helpers/talks_helper_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe TalksHelper, type: :helper do
-  describe "#time_with_zone_to_header" do
-    it "converts a TimeWithZone object to a header string" do
-      expect(helper.time_with_zone_to_header(Time.zone.parse('2023-10-27 12:34:56 JST +09:00'))).to eq("27日 12:34 ～")
-    end
-  end
-
   describe "#time_with_zone_to_anchor" do
     it "converts a TimeWithZone object to an anchor string" do
       expect(helper.time_with_zone_to_anchor(Time.zone.parse('2023-10-27 12:34:56 JST +09:00'))).to eq("1027-1234")


### PR DESCRIPTION
- fixes #81 
- I'm not picky about the appearance, so please feel free to tweak some of the UI :)
- I am concerned that I cannot return to the TOC by pressing the browser back button after clicking anchor links...

## PC view

### closed

<img width="800" alt="image" src="https://github.com/kaigionrails/conference-app/assets/8451003/7c2812f9-4448-4990-be05-b577ead9dd88">

### opened

<img width="800" alt="image" src="https://github.com/kaigionrails/conference-app/assets/8451003/d31c2cd7-8e92-481a-aa8b-ad231bcfbbaf">

## mobile

### closed

<img width="300" alt="image" src="https://github.com/kaigionrails/conference-app/assets/8451003/2bd1dcad-c96d-4af9-bd1e-643f7e6b75e3">

### opened

<img width="300" alt="image" src="https://github.com/kaigionrails/conference-app/assets/8451003/32b8ccea-8eef-47e2-bbed-862c126b8077">


