### PR TITLE
Start up conference-app-css along with conference-app when developing with docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,16 +26,25 @@ services:
     depends_on:
       - conference-app-db
       - conference-app-worker
+      - conference-app-css
   conference-app-css:
-    extends:
-      service: conference-app
     container_name: conference-app-css
+    env_file:
+      - .env
+      - envs/conference-app.env
     command:
       - sh
       - -c
       - |
         bundle install
         bin/rails tailwindcss:watch
+    build:
+      context: .
+    volumes:
+      - .:/app
+      - conference-app-bundle:/usr/local/bundle
+    stdin_open: true
+    tty: true
   conference-app-worker:
     container_name: conference-app-worker
     env_file:


### PR DESCRIPTION
Would like to start up conference-app-css when starting conference-app so the assets could be updated automatically when changing files.