### PR TITLE
Show flash messages

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -24,14 +24,14 @@ class Admin::AnnouncementsController < AdminController
   def update
     announcement = Announcement.find(params[:id])
     if announcement.update(**announcement_params)
-      flash.now[:success] = "Update succeeded"
+      flash[:success] = "Update succeeded"
       if announcement.previous_changes.has_key?("status") && announcement.previous_changes["status"] == ["draft", "published"]
         BroadcastAnnouncementJob.perform_later(announcement.id)
         SendAnnouncementPushNotificationJob.perform_later(announcement.id, push_notification_message(announcement))
       end
       redirect_to admin_announcement_path(announcement)
     else
-      flash.now[:alert] = "Update failed"
+      flash[:alert] = "Update failed"
       redirect_to edit_admin_announcement_path(announcement)
     end
   end

--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -18,10 +18,10 @@ class Admin::TalksController < AdminController
     start_at_time = update_params.delete(:start_at_time)
     start_at_with_zone = Time.zone.parse("#{start_at_date} #{start_at_time} +0900")
     if talk.update(**update_params, start_at: start_at_with_zone)
-      flash.now[:success] = "Update succeeded"
+      flash[:success] = "Update succeeded"
       redirect_to admin_talk_path(talk)
     else
-      flash.now[:alert] = "Update failed"
+      flash[:alert] = "Update failed"
       redirect_to edit_admin_talk_path(talk)
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -14,10 +14,10 @@ class Admin::UsersController < AdminController
   def update
     user = User.find(params[:id])
     if user.update(user_params)
-      flash.now[:success] = "Update succeeded"
+      flash[:success] = "Update succeeded"
       redirect_to admin_user_path(user)
     else
-      flash.now[:alert] = "Update failed"
+      flash[:alert] = "Update failed"
       redirect_to edit_admin_user_path(user)
     end
   end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -9,7 +9,7 @@ class AdminController < ApplicationController
     if logged_in? && current_user.organizer?
       # pass
     else
-      flash.now[:alert] = "Require organizer role"
+      flash[:alert] = "Require organizer role"
       redirect_to root_path
     end
   end

--- a/app/controllers/profile_badges_controller.rb
+++ b/app/controllers/profile_badges_controller.rb
@@ -19,9 +19,9 @@ class ProfileBadgesController < ApplicationController
       if params[:save_and_assign]
         current_user.profile.profile_badges << profile_badge
       end
-      flash.now[:success] = "保存に成功しました"
+      flash[:success] = "保存に成功しました"
     else
-      flash.now[:alert] = "保存に失敗しました"
+      flash[:alert] = "保存に失敗しました"
     end
     redirect_to new_profile_badge_path
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,15 @@ module ApplicationHelper
   def application_url
     Rails.configuration.application_url
   end
+
+  def message_type_style(message_type)
+    case message_type
+    when 'success'
+      'bg-[#d4edda]'
+    when 'alert'
+      'bg-[#f8d7da]'
+    else
+      ''
+    end
+  end
 end

--- a/app/views/layouts/application.html+mobile.erb
+++ b/app/views/layouts/application.html+mobile.erb
@@ -20,6 +20,11 @@
 
   <body class="bg-[#84240f] w-full flex flex-col h-[100dvh]">
     <%= render partial: "layouts/header_nav" %>
+    <% flash.each do |message_type, message| %>
+      <div class="py-3 px-5 mb-4 <%= message_type_style(message_type) %>">
+        <%= message %>
+      </div>
+    <% end %>
     <main class="w-full mx-auto pb-2 flex text-white flex-grow overflow-scroll">
       <%= yield %>
     </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,11 @@
 
   <body class="bg-[#84240f] w-full">
     <%= render partial: "layouts/header_nav" %>
+    <% flash.each do |message_type, message| %>
+      <div class="py-3 px-5 mb-4 <%= message_type_style(message_type) %>">
+        <%= message %>
+      </div>
+    <% end %>
     <main class="mx-auto flex text-white">
       <%= yield %>
     </main>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "#message_type_style" do
+    context "when message type is success" do
+      it "returns success message style" do
+        expect(helper.message_type_style('success')).to eq('bg-[#d4edda]')
+      end
+    end
+
+    context "when message type is alert" do
+      it "returns alert message style" do
+        expect(helper.message_type_style('alert')).to eq('bg-[#f8d7da]')
+      end
+    end
+
+    context "when message type is not expected" do
+      it "returns an empty string" do
+        expect(helper.message_type_style('hoge')).to eq('')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Should fix: https://github.com/kaigionrails/conference-app/issues/82
It looked like the flash message rendering was missing in the view template.
Feel free to tweak the designs if needed!

| success | alert |
----|---- 
| <img width="400" alt="Screenshot 2023-10-29 at 19 16 20" src="https://github.com/kaigionrails/conference-app/assets/3862661/6e25b1fd-0e52-4595-b4b2-2775454a8dd3"> | <img width="400" alt="Screenshot 2023-10-29 at 19 36 23" src="https://github.com/kaigionrails/conference-app/assets/3862661/49122526-878b-4865-845e-9637b20b86c3"> |