### PR TITLE
RBS: Decleare Profile#profile_badges manually

### DIFF
--- a/sig/handwritten/app/models/profile.rbs
+++ b/sig/handwritten/app/models/profile.rbs
@@ -1,4 +1,9 @@
 class Profile < ::ApplicationRecord
+  # NOTE: This method has been declared manually because current rbs_rails does not support HABTM.
+  #       It should be removed if rbs_rails will support it.
+  #       refs: https://github.com/pocke/rbs_rails/pull/272
+  def profile_badges: () -> ProfileBadge::ActiveRecord_Associations_CollectionProxy
+
   def ensure_image_from_github: () -> void
 
   private def fetch_profile_image_from_github: () -> untyped


### PR DESCRIPTION
As a preparation of giving types to controllers, this adds types for `Profile#profile_badges` manually because current rbs_rails does not support HABTM association.  It should be removed if rbs_rails will support it in the future.

refs: https://github.com/pocke/rbs_rails/pull/272