### PR TITLE
RBS: Add types for Announcement::ActiveRecord_Relation#published

### DIFF
--- a/sig/handwritten/app/models/announcement.rbs
+++ b/sig/handwritten/app/models/announcement.rbs
@@ -3,4 +3,11 @@ class Announcement < ApplicationRecord
   #       It should be removed if rbs_rails will support it.
   #       refs: https://github.com/pocke/rbs_rails/pull/268
   def self.published: () -> Announcement::ActiveRecord_Relation
+
+  class ActiveRecord_Relation
+    # NOTE: This method has been declared manually because current rbs_rails does not support enum definitions.
+    #       It should be removed if rbs_rails will support it.
+    #       refs: https://github.com/pocke/rbs_rails/pull/268
+    def published: () -> self
+  end
 end


### PR DESCRIPTION
As a preparation of giving types to controllers, this adds types for `Announcement::ActiveRecord_Relation#published` manually because current rbs_rails does not support Rails7 style enums. It should be removed if rbs_rails will support it in the future.

refs: https://github.com/pocke/rbs_rails/pull/268