### PR TITLE
RBS: Add types for activestorage (ActiveStorage::Attached::Many)

### DIFF
--- a/sig/rbs_rails/model_dependencies.rbs
+++ b/sig/rbs_rails/model_dependencies.rbs
@@ -4,8 +4,7 @@ class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < Act
 end
 class ActiveStorage::Blob::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
 end
-module ActiveStorage
-end
+
 class ActiveStorage::Record < ActiveRecord::Base
 end
 class ActiveStorage::VariantRecord::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy

--- a/sig/shims/activestorage.rbs
+++ b/sig/shims/activestorage.rbs
@@ -1,0 +1,7 @@
+module ActiveStorage
+  class Attached
+    class Many
+      include _ActiveRecord_Relation[ActiveStorage::Attachment, Integer]
+    end
+  end
+end


### PR DESCRIPTION
`ActiveStorage::Attached::Many` delegates missing method calls to the `ActiveRecord::Relation` object; `#attachments`. Therefore it should support methods of `ActiveRecord::Relation`.

This is a copy of https://github.com/ruby/gem_rbs_collection/pull/482.

refs:

* https://github.com/rails/rails/blob/v7.1.0/activestorage/lib/active_storage/attached/many.rb#L27
* https://github.com/rails/rails/blob/v7.1.0/activestorage/lib/active_storage/attached/model.rb#L201