### PR TITLE
Fix controllers that do not check log-in status before running

### DIFF
--- a/app/controllers/sample_webpush_notifications_controller.rb
+++ b/app/controllers/sample_webpush_notifications_controller.rb
@@ -1,4 +1,6 @@
 class SampleWebpushNotificationsController < ApplicationController
+  before_action :require_logged_in
+
   def create
     subscriptions = current_user!.webpush_subscriptions
     message = {

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,4 +1,6 @@
 class TalksController < ApplicationController
+  before_action :require_logged_in
+
   def index
     @event = Event.find_by!(slug: params[:event_slug])
     @talks = Talk.eager_load(speakers: { avatar_attachment: :blob }).where(event: @event).order(:start_at, :track)

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,15 +1,13 @@
 class TalksController < ApplicationController
-  before_action :require_logged_in
-
   def index
     @event = Event.find_by!(slug: params[:event_slug])
     @talks = Talk.eager_load(speakers: { avatar_attachment: :blob }).where(event: @event).order(:start_at, :track)
-    @current_user_bookmarks = TalkBookmark.where(user: current_user!).to_ary
+    @current_user_bookmarks = logged_in? ? TalkBookmark.where(user: current_user!).to_ary : []
   end
 
   def show
     @event = Event.find_by!(slug: params[:event_slug])
     @talk = Talk.eager_load(speakers: { avatar_attachment: :blob }).find_by!(id: params[:id])
-    @current_user_bookmarks = TalkBookmark.where(user: current_user!, talk: @talk).to_ary
+    @current_user_bookmarks = logged_in? ? TalkBookmark.where(user: current_user!, talk: @talk).to_ary : []
   end
 end

--- a/app/controllers/webpush_subscription_controller.rb
+++ b/app/controllers/webpush_subscription_controller.rb
@@ -1,4 +1,6 @@
 class WebpushSubscriptionController < ApplicationController
+  before_action :require_logged_in
+
   def create
     WebpushSubscription.create!(
       user: current_user!,


### PR DESCRIPTION
This adds `before_action :require_logged_in` call to the controllers that expects that user is logged in.

refs: #122