### PR TITLE
Fix ProfilesController#update does not handle errors on the update

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -36,16 +36,16 @@ class ProfilesController < ApplicationController
     will_assign_profile_badge_ids = given_profile_badge_ids - assigned_profile_badge_ids
     will_remove_profile_badge_ids = assigned_profile_badge_ids - given_profile_badge_ids
 
-    ApplicationRecord.transaction do
-      profile.update!(**profile_non_image_params)
-      profile.images.attach([profile_image_params[:images]]) if profile_image_params[:images].present?
-      profile.profile_badges << ProfileBadge.where(restricted: false, id: will_assign_profile_badge_ids)
-      profile.profile_badges.destroy(ProfileBadge.where(restricted: false, id: will_remove_profile_badge_ids))
-    end
-    if profile
+    begin
+      ApplicationRecord.transaction do
+        profile.update!(**profile_non_image_params)
+        profile.images.attach([profile_image_params[:images]]) if profile_image_params[:images].present?
+        profile.profile_badges << ProfileBadge.where(restricted: false, id: will_assign_profile_badge_ids)
+        profile.profile_badges.destroy(ProfileBadge.where(restricted: false, id: will_remove_profile_badge_ids))
+      end
       flash[:success] = "プロフィールを更新しました。"
       redirect_to profiles_path
-    else
+    rescue
       flash[:alert] = "更新に失敗しました。再度やりなおしてください。"
       redirect_to edit_profile_path
     end


### PR DESCRIPTION
It seems the current implementation expects the `profile` variable may be changed into nil when the update failed.  But it must be always truthy and it raises an exception on failed.

It's better to use begin-rescue instead of if-else to handle exception and emit an error to the users.

This error was found via `Ruby::UnreachableBranch` error from Steep :-)

Note: The `UnreachableBranch` is not emmited by default.  Locally, I enabled the "strict" settings of Steep to find this bug.