### PR TITLE
Fix AnnouncementsController crashes when not logged in

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -2,12 +2,12 @@ class AnnouncementsController < ApplicationController
   def index
     @event = Event.find_by!(slug: params[:event_slug])
     @announcements = Announcement.where(event: @event).published.order(id: :desc, published_at: :desc)
-    @unread_announcements = logged_in? && current_user!.unread_announcements
+    @unread_announcements = logged_in? ? current_user!.unread_announcements : UnreadAnnouncement.none
   end
 
   def show
     @event = Event.find_by!(slug: params[:event_slug])
     @announcement = Announcement.where(event: @event).published.with_rich_text_content_and_embeds.find_by!(id: params[:id])
-    @unread_announcement = logged_in? && current_user!.unread_announcements.find_by(announcement: @announcement)
+    @unread_announcement = logged_in? ? current_user!.unread_announcements.find_by(announcement: @announcement) : nil
   end
 end

--- a/sig/handwritten/app/controllers/announcements_controller.rbs
+++ b/sig/handwritten/app/controllers/announcements_controller.rbs
@@ -1,0 +1,11 @@
+class AnnouncementsController < ApplicationController
+  @event: Event
+
+  @announcements: Announcement::ActiveRecord_Relation
+
+  @unread_announcements: UnreadAnnouncement::ActiveRecord_Associations_CollectionProxy | UnreadAnnouncement::ActiveRecord_Relation
+
+  @announcement: Announcement
+
+  @unread_announcement: UnreadAnnouncement?
+end

--- a/sig/prototype/app/controllers/announcements_controller.rbs
+++ b/sig/prototype/app/controllers/announcements_controller.rbs
@@ -1,14 +1,4 @@
 class AnnouncementsController < ApplicationController
-  @event: untyped
-
-  @announcements: untyped
-
-  @unread_announcements: untyped
-
-  @announcement: untyped
-
-  @unread_announcement: untyped
-
   def index: () -> untyped
 
   def show: () -> untyped


### PR DESCRIPTION
`@unread_announcements` becomes `false` when not logged in.  Then it will be crashed on rendering view.

This error was found via `Ruby::IncompatibleAssignment` error from Steep :-)

Note: The UnreachableBranch is not emmited by default. Locally, I enabled the "strict" settings of Steep to find this bug.