### PR TITLE
Introduce `standard-rails`

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,2 @@
+plugins:
+  - standard-rails

--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,9 @@ group :development, :test do
 
   gem "factory_bot_rails", "~> 6.2.0"
   gem "rspec-rails", "~> 6.0"
+
+  gem "standard"
+  gem "standard-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,7 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -211,6 +212,7 @@ GEM
       time
       uri
     openssl (3.2.0)
+    parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
@@ -281,8 +283,10 @@ GEM
       redis-store (>= 1.2, < 2)
     redis-store (1.9.2)
       redis (>= 4, < 6)
+    regexp_parser (2.8.3)
     reline (0.3.1)
       io-console (~> 0.5)
+    rexml (3.2.6)
     rspec-core (3.12.0)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.0)
@@ -300,6 +304,27 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.12.0)
+    rubocop (1.57.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.4)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    rubocop-performance (1.19.1)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.20.2)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.33.0, < 2.0)
+    ruby-progressbar (1.13.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
@@ -327,6 +352,21 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
+    standard (1.32.1)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.57.2)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.2)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.2.1)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.19.1)
+    standard-rails (0.2.0)
+      lint_roller (~> 1.0)
+      rubocop-rails (~> 2.20.2)
     steep (1.5.3)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
@@ -421,6 +461,8 @@ DEPENDENCIES
   sentry-rails
   sidekiq
   sidekiq-cron
+  standard
+  standard-rails
   steep
   stimulus-rails
   tailwindcss-rails


### PR DESCRIPTION
Currently there's no linter for this app.
While we can setup our own configuration for RuboCop, I'd like to try `standard-rails`, which more devs can agree with.