### PR TITLE
Automated run standardrb

### DIFF
--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -1,0 +1,18 @@
+name: Run standardrb
+
+on:
+  push:
+    branches:
+      - "*"
+
+jobs:
+  standardrb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3.0"
+          bundler-cache: true
+      - name: standardrb
+        run: bundle exec standardrb

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3.0"
           bundler-cache: true
       - name: standardrb
         run: bundle exec standardrb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3.0"
           bundler-cache: true
       - run: bundle exec rails db:schema:load
       - run: bundle exec rails tailwindcss:build

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3.0"
           bundler-cache: true
       - run: bundle exec rbs collection install
       - run: bundle exec steep validate

--- a/config/initializers/prosopite.rb
+++ b/config/initializers/prosopite.rb
@@ -1,4 +1,4 @@
 unless Rails.env.production?
-  require 'prosopite/middleware/rack'
+  require "prosopite/middleware/rack"
   Rails.configuration.middleware.use(Prosopite::Middleware::Rack)
 end

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Profiles", type: :request do
   before { prepare_current_event }
   let(:user) { FactoryBot.create(:user) }
-  let!(:profile) { FactoryBot.create(:profile, :with_image, user: user)}
+  let!(:profile) { FactoryBot.create(:profile, :with_image, user: user) }
 
   describe "GET /index" do
     before do


### PR DESCRIPTION
- Added workflow to prevent main branch standardrb from failing
- run `bundle exec standardrb --fix`

## result
### [failed workflow](https://github.com/obregonia1/conference-app/actions/runs/7773690386/job/21197647062)
83ac86b4166ad1ad20f9b5f425f45275d8f36f93
![image](https://github.com/kaigionrails/conference-app/assets/75117116/e36e87f4-6beb-495f-855f-05d4ebbb0f04)

### [passed workflow](https://github.com/obregonia1/conference-app/actions/runs/7774203056)
ed209476d1b2a03e463060c0a08ce21e60100c38
![image](https://github.com/kaigionrails/conference-app/assets/75117116/317e8cb8-edc4-4626-96e1-c39ec10314a9)

## suggention
How about adding the success of this workflow as a mandatory condition for merging the PR?
