### PR TITLE
Excluded dependabot from the contributors list

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
           /repos/kaigionrails/conference-app/contributors \
-          | jq 'map({login, html_url})' > contributors.json
+          | jq 'map(select(.login != "dependabot[bot]")) | map({login, html_url})' > contributors.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set Current Date Variable


### PR DESCRIPTION
I excluded dependabot from the contributors list because I thought it was unnecessary to display it.

## command result
```shell
gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
  /repos/kaigionrails/conference-app/contributors \
  | jq 'map(select(.login != "dependabot[bot]")) | map({login, html_url})'

[
  {
    "login": "unasuke",
    "html_url": "https://github.com/unasuke"
  },
  {
    "login": "tk0miya",
    "html_url": "https://github.com/tk0miya"
  },
  {
    "login": "okuramasafumi",
    "html_url": "https://github.com/okuramasafumi"
  },
  {
    "login": "fugakkbn",
    "html_url": "https://github.com/fugakkbn"
  },
  {
    "login": "indigolain",
    "html_url": "https://github.com/indigolain"
  },
  {
    "login": "obregonia1",
    "html_url": "https://github.com/obregonia1"
  },
  {
    "login": "megane42",
    "html_url": "https://github.com/megane42"
  },
  {
    "login": "geeknees",
    "html_url": "https://github.com/geeknees"
  },
  {
    "login": "4geru",
    "html_url": "https://github.com/4geru"
  },
  {
    "login": "hayaokimura",
    "html_url": "https://github.com/hayaokimura"
  },
  {
    "login": "nekonenene",
    "html_url": "https://github.com/nekonenene"
  }
]
```