### PR TITLE
Make talk pages able to see when not logged-in

### DIFF
--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -30,7 +30,9 @@
                 <% end %>
                 <p class="text-sm block mb-3"><%= talk.track %></p>
                 <div class="w-6 h-6 -ml-1">
-                  <%= render partial: "bookmark_button", locals: { talk: talk, user: current_user!, user_bookmarks: @current_user_bookmarks } %>
+                  <% if logged_in? %>
+                    <%= render partial: "bookmark_button", locals: { talk: talk, user: current_user!, user_bookmarks: @current_user_bookmarks } %>
+                  <% end %>
                 </div>
               </div>
               <div class="w-full pl-2">

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -7,7 +7,9 @@
       <span><%= "#{@talk.duration_minutes} 分間" %></span>
     </div>
     <div class="w-8 h-8">
-      <%= render partial: "bookmark_button", locals: { talk: @talk, user: current_user!, user_bookmarks: @current_user_bookmarks } %>
+      <% if logged_in? %>
+        <%= render partial: "bookmark_button", locals: { talk: @talk, user: current_user!, user_bookmarks: @current_user_bookmarks } %>
+      <% end %>
     </div>
   </div>
   <div class="mb-4 md:mb-6">

--- a/spec/requests/talks_spec.rb
+++ b/spec/requests/talks_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Talks", type: :request do
   let(:event) { FactoryBot.create(:event) }

--- a/spec/requests/talks_spec.rb
+++ b/spec/requests/talks_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe "Talks", type: :request do
+  let(:event) { FactoryBot.create(:event) }
+  let(:talk) { FactoryBot.create(:talk, event: event) }
+
+  before { prepare_current_event(event) }
+
+  describe "GET /:event_slug/talks" do
+    context "not logged in" do
+      it "should able to see talks without logged-in" do
+        get event_talks_path(event_slug: talk.event.slug)
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "logged in" do
+      let(:user) { FactoryBot.create(:user) }
+
+      before { sign_in(user) }
+      it "should able to see talks" do
+        get event_talks_path(event_slug: talk.event.slug)
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+
+  describe "GET /:event/slug/talks/:id" do
+    context "not logged in" do
+      it "should able to see talk without logged-in" do
+        get event_talk_path(event_slug: talk.event.slug, id: talk.id)
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "logged in" do
+      let(:user) { FactoryBot.create(:user) }
+
+      before { sign_in(user) }
+      it "should able to see talk" do
+        get event_talk_path(event_slug: talk.event.slug, id: talk.id)
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+end

--- a/spec/support/event_helper.rb
+++ b/spec/support/event_helper.rb
@@ -1,6 +1,6 @@
 module EventHelper
-  def prepare_current_event
-    allow_any_instance_of(ApplicationHelper).to receive(:current_event).and_return(prepare_event)
+  def prepare_current_event(event = nil)
+    allow_any_instance_of(ApplicationHelper).to receive(:current_event).and_return(event || prepare_event)
   end
 
   private def prepare_event


### PR DESCRIPTION
## What
Since #122 , `/2023/talks` and `/2023/talks/id` couldn't see when not logged in.

This patch fix it.