### PR TITLE
Remove marcel.rbs from shim

### DIFF
--- a/sig/shims/marcel.rbs
+++ b/sig/shims/marcel.rbs
@@ -1,9 +1,0 @@
-module Marcel
-  class Magic
-    attr_reader type: String
-    attr_reader mediatype: String
-    attr_reader subtype: String
-
-    def self.by_magic: (IO) -> instance
-  end
-end


### PR DESCRIPTION
## What

gem_rbs_collecton has marcel rbs.

https://github.com/kaigionrails/conference-app/actions/runs/9049570822 fails because this repo has duplicated type defs of marcel.