### PR TITLE
deps: We want to upgrade Rails manually

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    exclude-patterns:
+      - "rails"
+      - "actionpack"
+      - "actiontext"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot should ignore them.
Listed only `actionpack` and `actiontext` here, but we might need to add other gems as well.