### PR TITLE
Fix dependabot ignore rule for rails gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    exclude-patterns:
-      - "rails"
-      - "actionpack"
-      - "actiontext"
+    ignore:
+      - dependency-name: "rails"
+      - dependency-name: "actionpack"
+      - dependency-name: "actiontext"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Followup #237 

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore