### PR TITLE
Configure load_defaults to current rails version

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ Bundler.require(*Rails.groups)
 module ConferenceApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults 7.1
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.


### PR DESCRIPTION
Current rails version was successfully updated to 7.1 with https://github.com/kaigionrails/conference-app/pull/232.
It seems safe to load the default config for v7.1?