### PR TITLE
セッションの詳細画面から一覧に戻るリンクにanchorを追加する

### DIFF
--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -44,5 +44,5 @@
       </div>
     <% end %>
   </div>
-  <%= link_to "発表一覧に戻る", event_talks_path(event_slug: @event.slug), class: "underline inline-block mb-8" %>
+  <%= link_to "発表一覧に戻る", event_talks_path(event_slug: @event.slug, anchor: time_with_zone_to_anchor(@talk.start_at)), class: "underline inline-block mb-8" %>
 </div>


### PR DESCRIPTION
セッションの詳細画面から一覧に戻ると、画面トップに戻ってしまい使いにくかったので、リンクにanchorを追加しました。