### PR TITLE
Respect safe areas on mobile platforms

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -37,3 +37,9 @@
     @apply list-decimal
   }
 }
+
+@layer utilities {
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}

--- a/app/views/layouts/application.html+mobile.erb
+++ b/app/views/layouts/application.html+mobile.erb
@@ -18,7 +18,7 @@
     </script>
   </head>
 
-  <body class="bg-[#d7d2d0] w-full flex flex-col h-[100dvh]">
+  <body class="bg-[#d7d2d0] w-full flex flex-col h-[100dvh] pb-safe">
     <%= render partial: "layouts/header_nav" %>
     <% flash.each do |message_type, message| %>
       <div class="py-3 px-5 mb-4 <%= message_type_style(message_type) %>">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     </script>
   </head>
 
-  <body class="bg-[#d7d2d0] w-full">
+  <body class="bg-[#d7d2d0] w-full pb-safe">
     <%= render partial: "layouts/header_nav" %>
     <% flash.each do |message_type, message| %>
       <div class="py-3 px-5 mb-4 <%= message_type_style(message_type) %>">


### PR DESCRIPTION
アナウンスを読んでいるとき、 `<< アナウンス一覧に戻る` が safe area にかぶってタップできないのを修正した、つもりです。
https://developer.mozilla.org/en-US/docs/Web/CSS/env

(conference-app を手元で動かすのに成功していないので勘で修正しています)

![IMG_5409](https://github.com/user-attachments/assets/f1790990-d307-4059-b068-ad2b932c7898)
