### PR TITLE
viewport-fit=cover

### DIFF
--- a/app/views/layouts/application.html+mobile.erb
+++ b/app/views/layouts/application.html+mobile.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title><%= page_title(yield(:page_title)) %></title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>


### PR DESCRIPTION
Follow-up of https://github.com/kaigionrails/conference-app/pull/327 .

viewport-fit=cover is required for using env(safe-area-inset-bottom).

---

そもそも viewport-fit=cover 的な挙動になっている気がしますが、いずれにせよ明示的に指定しないことには safe-area-inset-bottom を使えないので追加してみました。

<img width="376" alt="image" src="https://github.com/user-attachments/assets/3815ac79-e0ea-4091-888f-ac21566e1ab3">
