### PR TITLE
Disable turbolinks of event talks path.

### DIFF
--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -44,5 +44,5 @@
       </div>
     <% end %>
   </div>
-  <%= link_to "発表一覧に戻る", event_talks_path(event_slug: @event.slug, anchor: time_with_zone_to_anchor(@talk.start_at)), class: "underline inline-block mb-8" %>
+  <%= link_to "発表一覧に戻る", event_talks_path(event_slug: @event.slug, anchor: time_with_zone_to_anchor(@talk.start_at)), class: "underline inline-block mb-8", data: {"turbolinks" => false} %>
 </div>


### PR DESCRIPTION
セッション詳細ページから一覧ページに戻ったときに、アンカーで示された箇所に正しく戻るよう turbolinks を無効にしてみました。