### PR TITLE
Show/hide unread ann badge based on current event anns only

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,11 @@ class User < ApplicationRecord
   enum :role, {organizer: "organizer", participant: "participant", operator: "operator"}
 
   def have_unread_announcements?
-    unread_announcements.joins(:announcement).where(announcement: {event: current_event}).exists?
+    unread_announcement_count > 0
+  end
+
+  def unread_announcement_count
+    unread_announcements.joins(:announcement).where(announcement: {event: current_event}).count
   end
 
   def mark_all_announcement_unread!(event = nil)

--- a/app/views/layouts/_header_nav.html.erb
+++ b/app/views/layouts/_header_nav.html.erb
@@ -45,7 +45,7 @@
           <%= link_to event_announcements_path(event_slug: current_event.slug), class: "py-2 text-lg hover:bg-gray-100 text-gray-900 rounded-lg pl-3" do %>
             <span>Announcements</span>
             <% if logged_in? && current_user!.have_unread_announcements? %>
-              <span class="rounded-xl bg-red-300 px-3 text-sm ml-2"><%= current_user!.unread_announcements.count %></span>
+              <span class="rounded-xl bg-red-300 px-3 text-sm ml-2"><%= current_user!.unread_announcement_count %></span>
             <% end %>
           <% end %>
           <% if logged_in? %>


### PR DESCRIPTION
Possibly fixes https://github.com/kaigionrails/conference-app/issues/335 .

- 未読バッジの表示のオンオフは current_event だけを見て判定している
- 一方、表示する場合の数は過去のイベントの未読数も算入している

のうち、後者を解消するねらい。