### PR TITLE
sig: Adjust log level of UnknownInstanceVariable to hint

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -1,19 +1,13 @@
-# D = Steep::Diagnostic
-#
+D = Steep::Diagnostic
+
 target :lib do
   signature "sig"
 
   check "app"
-  # ignore "lib/templates/*.rb"
 
-  # library "pathname", "set"       # Standard libraries
-  # library "strong_json"           # Gems
-
-  # configure_code_diagnostics(D::Ruby.strict)       # `strict` diagnostics setting
-  # configure_code_diagnostics(D::Ruby.lenient)      # `lenient` diagnostics setting
-  # configure_code_diagnostics do |hash|             # You can setup everything yourself
-  #   hash[D::Ruby::NoMethod] = :information
-  # end
+  configure_code_diagnostics do |hash|
+    hash[D::Ruby::UnknownInstanceVariable] = :hint
+  end
 end
 
 # target :test do


### PR DESCRIPTION
RBS::Inline does not generate prototype signature for instance variables.  Therefore Steep emits UnknownInstanceVariable to our code using instance variables.

This adjust the log level of the diagnostics to hint.


Sorry, this must be included in https://github.com/kaigionrails/conference-app/pull/345. I forget to add this.