### PR TITLE
add: description of GITHUB_PRIVATE_KEY

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,6 +6,8 @@ GITHUB_APP_ID=0000000
 GITHUB_KEY=Iv1.xxxxxxxxxxxxxxx
 GITHUB_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# Set the private key of the GitHub app.
+# See also https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps
 # openssl pkey -in /path/to/private-key.pem -outform der | openssl base64 -A
 GITHUB_PRIVATE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 


### PR DESCRIPTION
# About

This shows the details of the contents expected for GITHUB_PRIVATE_KEY in the .env file.

## Why

I wanted to improve it because I didn't know which secret key needed to be set because I wasn't familiar with GitHub Apps.

## Expected effects

It may become easier for many developers to set up, and there may be an increase in contributions.