### PR TITLE
fix: Explanatory text that is also compatible with 2024 and beyond

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ Then, fill these environment variables.
 $ bin/rails db:seed
 ```
 
-After that, you can see 2023's event talks and speakers.
+After that, you can see event talks and speakers for 2023 and beyond.
+
+- 2023: http://localhost:3000/2023/talks
+- 2024: http://localhost:3000/2024/talks
 
 ## Setup dev environment with docker
 ```bash


### PR DESCRIPTION
The README text is still from 2023, so I'll fix it.