### PR TITLE
sig: Replace types of gems by upstream

### DIFF
--- a/app/controllers/admin/signages_controller.rb
+++ b/app/controllers/admin/signages_controller.rb
@@ -4,7 +4,7 @@ class Admin::SignagesController < AdminController
       signage_schedules: [
         {signage_pages: {page_image_attachment: :blob}},
         {signage_schedule_assigns: :signage_panel}
-      ] # steep:ignore
+      ]
     ).all
     @signage_panels = SignagePanel.all
     @signage_devices = SignageDevice.all

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -121,6 +121,14 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: commonmarker
+  version: '1.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 0ca3010179414639bcb0b18ae1627aef70f26128
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: concurrent-ruby
   version: '1.1'
   source:
@@ -365,6 +373,14 @@ gems:
     revision: 704f7e6b395fca717cc25c562598ca86015ed545
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: rails-html-sanitizer
+  version: '1.6'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 0ca3010179414639bcb0b18ae1627aef70f26128
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: railties
   version: '6.0'
   source:
@@ -442,10 +458,6 @@ gems:
   source:
     type: stdlib
 - name: socket
-  version: '0'
-  source:
-    type: stdlib
-- name: strscan
   version: '0'
   source:
     type: stdlib

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionmailer
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionpack
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionview
@@ -30,7 +30,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: active_decorator
@@ -38,7 +38,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activejob
@@ -46,7 +46,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activemodel
@@ -54,7 +54,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activerecord
@@ -62,15 +62,15 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activestorage
-  version: '6.1'
+  version: '7.0'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activesupport
@@ -78,7 +78,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: addressable
@@ -86,7 +86,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -94,7 +94,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: base64
@@ -106,7 +106,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: benchmark
@@ -126,7 +126,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 0ca3010179414639bcb0b18ae1627aef70f26128
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: concurrent-ruby
@@ -134,7 +134,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -142,7 +142,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
@@ -158,7 +158,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: erb
@@ -170,7 +170,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: fileutils
@@ -186,7 +186,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: google-protobuf
@@ -194,7 +194,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: hashdiff
@@ -202,7 +202,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 218cf130d31f63e110e350efc3fa265311b0f238
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: hashie
@@ -210,7 +210,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: i18n
@@ -218,7 +218,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: io-console
@@ -234,7 +234,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: kaminari-core
@@ -242,7 +242,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -254,7 +254,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: marcel
@@ -262,7 +262,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: mini_magick
@@ -270,7 +270,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: mini_mime
@@ -278,7 +278,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: minitest
@@ -310,7 +310,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: octokit
@@ -318,7 +318,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: open-uri
@@ -334,7 +334,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parser
@@ -342,7 +342,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: pathname
@@ -362,7 +362,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-dom-testing
@@ -370,7 +370,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-html-sanitizer
@@ -378,7 +378,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 0ca3010179414639bcb0b18ae1627aef70f26128
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: railties
@@ -386,7 +386,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -394,7 +394,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -402,7 +402,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rdoc
@@ -414,7 +414,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: regexp_parser
@@ -422,7 +422,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop
@@ -430,7 +430,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-ast
@@ -438,7 +438,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: securerandom
@@ -450,7 +450,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: singleton
@@ -470,7 +470,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: time
@@ -490,7 +490,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: uri
@@ -502,7 +502,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: webmock
@@ -510,7 +510,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 218cf130d31f63e110e350efc3fa265311b0f238
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: woothee
@@ -518,7 +518,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock

--- a/sig/rbs_rails/model_dependencies.rbs
+++ b/sig/rbs_rails/model_dependencies.rbs
@@ -14,7 +14,8 @@ class SolidQueue::Process::ActiveRecord_Associations_CollectionProxy < ActiveRec
 end
 class SolidQueue::Execution < SolidQueue::Record
 end
-
+module ActiveStorage
+end
 class ActiveStorage::Record < ActiveRecord::Base
 end
 class ActiveStorage::VariantRecord::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy

--- a/sig/shims/activestorage.rbs
+++ b/sig/shims/activestorage.rbs
@@ -1,6 +1,0 @@
-module ActiveStorage
-  class Current < ActiveSupport::CurrentAttributes
-    def self.url_options: () -> untyped
-    def self.url_options=: (untyped) -> untyped
-  end
-end

--- a/sig/shims/commonmarker.rbs
+++ b/sig/shims/commonmarker.rbs
@@ -1,3 +1,0 @@
-module Commonmarker
-  def self.to_html: (String text, ?Hash[untyped, untyped] options, ?Hash[untyped, untyped] plugins) -> String
-end

--- a/sig/shims/rails-html-sanitizer.rbs
+++ b/sig/shims/rails-html-sanitizer.rbs
@@ -1,9 +1,0 @@
-module Rails
-  module HTML
-    class SafeListSanitizer
-      def sanitize: (String html, untyped options) -> String
-    end
-  end
-
-  module Html = HTML
-end


### PR DESCRIPTION
The types of commonmarker and rails-html-sanitizer are now registered to gem_rbs_collection.  They are **developed in this repo** and moved to common types repository now.

* https://github.com/ruby/gem_rbs_collection/pull/704
* https://github.com/ruby/gem_rbs_collection/pull/705