### PR TITLE
sig: rbs:subtract is no longer needed 

### DIFF
--- a/app/controllers/admin/signages_controller.rb
+++ b/app/controllers/admin/signages_controller.rb
@@ -4,7 +4,7 @@ class Admin::SignagesController < AdminController
       signage_schedules: [
         {signage_pages: {page_image_attachment: :blob}},
         {signage_schedule_assigns: :signage_panel}
-      ] # steep:ignore
+      ]
     ).all
     @signage_panels = SignagePanel.all
     @signage_devices = SignageDevice.all

--- a/lib/tasks/rbs.rake
+++ b/lib/tasks/rbs.rake
@@ -2,7 +2,7 @@ if Rails.env.local?
   require "rbs_rails/rake_task"
 
   namespace :rbs do
-    task setup: %i[clean collection generate load_routes rbs_rails:all subtract]
+    task setup: %i[clean collection generate load_routes rbs_rails:all validate]
 
     task :clean do
       sh "rm", "-rf", "sig/rbs_rails/"
@@ -22,17 +22,6 @@ if Rails.env.local?
       # Since Rails 8.0, route drawing has been defered to the first request.
       # This forcedly do route drawing to generate path_helpers via rbs_rails.
       Rails.application.reload_routes_unless_loaded
-    end
-
-    task :subtract do
-      sh "rbs", "subtract", "--write", "sig/generated", "sig/rbs_rails"
-
-      generated_path = Rails.root.join("sig/generated")
-      rbs_rails_path = Rails.root.join("sig/rbs_rails")
-      subtrahends = Rails.root.glob("sig/*")
-        .reject { |path| path == generated_path || path == rbs_rails_path }
-        .map { |path| "--subtrahend=#{path}" }
-      sh "rbs", "subtract", "--write", "sig/generated", "sig/rbs_rails", *subtrahends
     end
 
     task :validate do

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -121,6 +121,14 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: commonmarker
+  version: '1.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 0ca3010179414639bcb0b18ae1627aef70f26128
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: concurrent-ruby
   version: '1.1'
   source:
@@ -365,6 +373,14 @@ gems:
     revision: 704f7e6b395fca717cc25c562598ca86015ed545
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: rails-html-sanitizer
+  version: '1.6'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 0ca3010179414639bcb0b18ae1627aef70f26128
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: railties
   version: '6.0'
   source:
@@ -442,10 +458,6 @@ gems:
   source:
     type: stdlib
 - name: socket
-  version: '0'
-  source:
-    type: stdlib
-- name: strscan
   version: '0'
   source:
     type: stdlib

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionmailer
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionpack
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionview
@@ -30,7 +30,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: active_decorator
@@ -38,7 +38,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activejob
@@ -46,7 +46,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activemodel
@@ -54,7 +54,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activerecord
@@ -62,15 +62,15 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activestorage
-  version: '6.1'
+  version: '7.0'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activesupport
@@ -78,7 +78,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: addressable
@@ -86,7 +86,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -94,7 +94,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: base64
@@ -106,7 +106,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: benchmark
@@ -126,7 +126,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 0ca3010179414639bcb0b18ae1627aef70f26128
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: concurrent-ruby
@@ -134,7 +134,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -142,7 +142,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
@@ -158,7 +158,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: erb
@@ -170,7 +170,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: fileutils
@@ -186,7 +186,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: google-protobuf
@@ -194,7 +194,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: hashdiff
@@ -202,7 +202,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 218cf130d31f63e110e350efc3fa265311b0f238
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: hashie
@@ -210,7 +210,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: i18n
@@ -218,7 +218,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: io-console
@@ -234,7 +234,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: kaminari-core
@@ -242,7 +242,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -254,7 +254,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: marcel
@@ -262,7 +262,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: mini_magick
@@ -270,7 +270,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: mini_mime
@@ -278,7 +278,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: minitest
@@ -310,7 +310,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: octokit
@@ -318,7 +318,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: open-uri
@@ -334,7 +334,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parser
@@ -342,7 +342,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: pathname
@@ -362,7 +362,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-dom-testing
@@ -370,7 +370,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-html-sanitizer
@@ -378,7 +378,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 0ca3010179414639bcb0b18ae1627aef70f26128
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: railties
@@ -386,7 +386,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -394,7 +394,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -402,7 +402,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rdoc
@@ -414,7 +414,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: regexp_parser
@@ -422,7 +422,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop
@@ -430,7 +430,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-ast
@@ -438,7 +438,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: securerandom
@@ -450,7 +450,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: singleton
@@ -470,7 +470,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: time
@@ -490,7 +490,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: uri
@@ -502,7 +502,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: webmock
@@ -510,7 +510,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 218cf130d31f63e110e350efc3fa265311b0f238
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: woothee
@@ -518,7 +518,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 704f7e6b395fca717cc25c562598ca86015ed545
+    revision: df0b86dbc3a9f2bd6eecce3bec95b48b0246ab8e
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock

--- a/sig/generated/channels/application_cable/channel.rbs
+++ b/sig/generated/channels/application_cable/channel.rbs
@@ -1,3 +1,5 @@
+# Generated from app/channels/application_cable/channel.rb with RBS::Inline
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/sig/generated/channels/application_cable/connection.rbs
+++ b/sig/generated/channels/application_cable/connection.rbs
@@ -1,3 +1,5 @@
+# Generated from app/channels/application_cable/connection.rb with RBS::Inline
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/sig/generated/cloudflare_api_client.rbs
+++ b/sig/generated/cloudflare_api_client.rbs
@@ -1,3 +1,5 @@
+# Generated from lib/cloudflare_api_client.rb with RBS::Inline
+
 class CloudflareApiClient
   @account_id: String
 

--- a/sig/generated/controllers/about_controller.rbs
+++ b/sig/generated/controllers/about_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/about_controller.rb with RBS::Inline
+
 class AboutController < ApplicationController
   def index: () -> untyped
 end

--- a/sig/generated/controllers/admin.rbs
+++ b/sig/generated/controllers/admin.rbs
@@ -1,2 +1,4 @@
+# Generated from app/controllers/admin.rb with RBS::Inline
+
 module Admin
 end

--- a/sig/generated/controllers/admin/announcements_controller.rbs
+++ b/sig/generated/controllers/admin/announcements_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/announcements_controller.rb with RBS::Inline
+
 class Admin::AnnouncementsController < AdminController
   @announcements: Announcement::ActiveRecord_Relation
 

--- a/sig/generated/controllers/admin/events_controller.rbs
+++ b/sig/generated/controllers/admin/events_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/events_controller.rb with RBS::Inline
+
 class Admin::EventsController < AdminController
   def index: () -> untyped
 

--- a/sig/generated/controllers/admin/live_streams_controller.rbs
+++ b/sig/generated/controllers/admin/live_streams_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/live_streams_controller.rb with RBS::Inline
+
 class Admin::LiveStreamsController < AdminController
   def index: () -> untyped
 

--- a/sig/generated/controllers/admin/ongoing_events_controller.rbs
+++ b/sig/generated/controllers/admin/ongoing_events_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/ongoing_events_controller.rb with RBS::Inline
+
 class Admin::OngoingEventsController < ApplicationController
   def update: () -> untyped
 

--- a/sig/generated/controllers/admin/profile_badges_controller.rbs
+++ b/sig/generated/controllers/admin/profile_badges_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/profile_badges_controller.rb with RBS::Inline
+
 class Admin::ProfileBadgesController < AdminController
   @profile_badges: ProfileBadge::ActiveRecord_Relation
 

--- a/sig/generated/controllers/admin/profile_badges_profiles_controller.rbs
+++ b/sig/generated/controllers/admin/profile_badges_profiles_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/profile_badges_profiles_controller.rb with RBS::Inline
+
 class Admin::ProfileBadgesProfilesController < AdminController
   @profile: Profile
 

--- a/sig/generated/controllers/admin/signage_device_assigns_controller.rbs
+++ b/sig/generated/controllers/admin/signage_device_assigns_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/signage_device_assigns_controller.rb with RBS::Inline
+
 class Admin::SignageDeviceAssignsController < AdminController
   def new: () -> untyped
 

--- a/sig/generated/controllers/admin/signage_devices_controller.rbs
+++ b/sig/generated/controllers/admin/signage_devices_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/signage_devices_controller.rb with RBS::Inline
+
 class Admin::SignageDevicesController < AdminController
   def new: () -> untyped
 

--- a/sig/generated/controllers/admin/signage_pages_controller.rbs
+++ b/sig/generated/controllers/admin/signage_pages_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/signage_pages_controller.rb with RBS::Inline
+
 class Admin::SignagePagesController < AdminController
   def index: () -> untyped
 

--- a/sig/generated/controllers/admin/signage_panels_controller.rbs
+++ b/sig/generated/controllers/admin/signage_panels_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/signage_panels_controller.rb with RBS::Inline
+
 class Admin::SignagePanelsController < AdminController
   def new: () -> untyped
 

--- a/sig/generated/controllers/admin/signage_schedule_assigns_controller.rbs
+++ b/sig/generated/controllers/admin/signage_schedule_assigns_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/signage_schedule_assigns_controller.rb with RBS::Inline
+
 class Admin::SignageScheduleAssignsController < AdminController
   def new: () -> untyped
 

--- a/sig/generated/controllers/admin/signage_schedules_controller.rbs
+++ b/sig/generated/controllers/admin/signage_schedules_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/signage_schedules_controller.rb with RBS::Inline
+
 class Admin::SignageSchedulesController < AdminController
   def new: () -> untyped
 

--- a/sig/generated/controllers/admin/signages_controller.rbs
+++ b/sig/generated/controllers/admin/signages_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/signages_controller.rb with RBS::Inline
+
 class Admin::SignagesController < AdminController
   def index: () -> untyped
 

--- a/sig/generated/controllers/admin/talks_controller.rbs
+++ b/sig/generated/controllers/admin/talks_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/talks_controller.rb with RBS::Inline
+
 class Admin::TalksController < AdminController
   @talks: Talk::ActiveRecord_Relation
 

--- a/sig/generated/controllers/admin/users_controller.rbs
+++ b/sig/generated/controllers/admin/users_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin/users_controller.rb with RBS::Inline
+
 class Admin::UsersController < AdminController
   @users: User::ActiveRecord_Relation
 

--- a/sig/generated/controllers/admin_controller.rbs
+++ b/sig/generated/controllers/admin_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/admin_controller.rb with RBS::Inline
+
 class AdminController < ApplicationController
   def index: () -> untyped
 

--- a/sig/generated/controllers/announcements_controller.rbs
+++ b/sig/generated/controllers/announcements_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/announcements_controller.rb with RBS::Inline
+
 class AnnouncementsController < ApplicationController
   @event: Event
 

--- a/sig/generated/controllers/application_controller.rbs
+++ b/sig/generated/controllers/application_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/application_controller.rb with RBS::Inline
+
 class ApplicationController < ActionController::Base
   include _RbsRailsPathHelpers
 

--- a/sig/generated/controllers/auth_callback_controller.rbs
+++ b/sig/generated/controllers/auth_callback_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/auth_callback_controller.rb with RBS::Inline
+
 class AuthCallbackController < ApplicationController
   def create: () -> untyped
 end

--- a/sig/generated/controllers/events_controller.rbs
+++ b/sig/generated/controllers/events_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/events_controller.rb with RBS::Inline
+
 class EventsController < ApplicationController
   @event: Event
 

--- a/sig/generated/controllers/home_controller.rbs
+++ b/sig/generated/controllers/home_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/home_controller.rb with RBS::Inline
+
 class HomeController < ApplicationController
   def index: () -> untyped
 end

--- a/sig/generated/controllers/live_streams_controller.rbs
+++ b/sig/generated/controllers/live_streams_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/live_streams_controller.rb with RBS::Inline
+
 class LiveStreamsController < ApplicationController
   def show: () -> untyped
 end

--- a/sig/generated/controllers/operators_controller.rbs
+++ b/sig/generated/controllers/operators_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/operators_controller.rb with RBS::Inline
+
 class OperatorsController < ApplicationController
   def index: () -> untyped
 

--- a/sig/generated/controllers/profile_badges_controller.rbs
+++ b/sig/generated/controllers/profile_badges_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/profile_badges_controller.rb with RBS::Inline
+
 class ProfileBadgesController < ApplicationController
   @profile_badge: ProfileBadge
 

--- a/sig/generated/controllers/profile_images_controller.rbs
+++ b/sig/generated/controllers/profile_images_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/profile_images_controller.rb with RBS::Inline
+
 class ProfileImagesController < ApplicationController
   def destroy: () -> untyped
 end

--- a/sig/generated/controllers/profiles_controller.rbs
+++ b/sig/generated/controllers/profiles_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/profiles_controller.rb with RBS::Inline
+
 class ProfilesController < ApplicationController
   @profile: Profile
 

--- a/sig/generated/controllers/pwa_controller.rbs
+++ b/sig/generated/controllers/pwa_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/pwa_controller.rb with RBS::Inline
+
 class PwaController < ApplicationController
   def service_worker: () -> untyped
 

--- a/sig/generated/controllers/sample_webpush_notifications_controller.rbs
+++ b/sig/generated/controllers/sample_webpush_notifications_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/sample_webpush_notifications_controller.rb with RBS::Inline
+
 class SampleWebpushNotificationsController < ApplicationController
   def create: () -> untyped
 end

--- a/sig/generated/controllers/sessions_controller.rbs
+++ b/sig/generated/controllers/sessions_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/sessions_controller.rb with RBS::Inline
+
 class SessionsController < ApplicationController
   def new: () -> untyped
 

--- a/sig/generated/controllers/setting_controller.rbs
+++ b/sig/generated/controllers/setting_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/setting_controller.rb with RBS::Inline
+
 class SettingController < ApplicationController
   def index: () -> untyped
 end

--- a/sig/generated/controllers/signage_devices_controller.rbs
+++ b/sig/generated/controllers/signage_devices_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/signage_devices_controller.rb with RBS::Inline
+
 class SignageDevicesController < ApplicationController
   def index: () -> untyped
 end

--- a/sig/generated/controllers/signages_controller.rbs
+++ b/sig/generated/controllers/signages_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/signages_controller.rb with RBS::Inline
+
 class SignagesController < ApplicationController
   def index: () -> untyped
 end

--- a/sig/generated/controllers/talk_bookmarks_controller.rbs
+++ b/sig/generated/controllers/talk_bookmarks_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/talk_bookmarks_controller.rb with RBS::Inline
+
 class TalkBookmarksController < ApplicationController
   def create: () -> untyped
 

--- a/sig/generated/controllers/talks_controller.rbs
+++ b/sig/generated/controllers/talks_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/talks_controller.rb with RBS::Inline
+
 class TalksController < ApplicationController
   @event: Event
 

--- a/sig/generated/controllers/unread_announcements_controller.rbs
+++ b/sig/generated/controllers/unread_announcements_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/unread_announcements_controller.rb with RBS::Inline
+
 class UnreadAnnouncementsController < ApplicationController
   def destroy: () -> untyped
 end

--- a/sig/generated/controllers/users_controller.rbs
+++ b/sig/generated/controllers/users_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/users_controller.rb with RBS::Inline
+
 class UsersController < ApplicationController
   include ApplicationHelper
 

--- a/sig/generated/controllers/webpush_subscription_controller.rbs
+++ b/sig/generated/controllers/webpush_subscription_controller.rbs
@@ -1,3 +1,5 @@
+# Generated from app/controllers/webpush_subscription_controller.rb with RBS::Inline
+
 class WebpushSubscriptionController < ApplicationController
   def create: () -> untyped
 

--- a/sig/generated/decorators/profile_decorator.rbs
+++ b/sig/generated/decorators/profile_decorator.rbs
@@ -1,3 +1,5 @@
+# Generated from app/decorators/profile_decorator.rb with RBS::Inline
+
 # @rbs module-self Profile
 module ProfileDecorator : Profile
   def sanitized_description: () -> untyped

--- a/sig/generated/decorators/speaker_decorator.rbs
+++ b/sig/generated/decorators/speaker_decorator.rbs
@@ -1,3 +1,5 @@
+# Generated from app/decorators/speaker_decorator.rb with RBS::Inline
+
 # @rbs module-self Speaker
 module SpeakerDecorator : Speaker
   def sanitized_bio: () -> untyped

--- a/sig/generated/decorators/talk_decorator.rbs
+++ b/sig/generated/decorators/talk_decorator.rbs
@@ -1,3 +1,5 @@
+# Generated from app/decorators/talk_decorator.rb with RBS::Inline
+
 # @rbs module-self Talk
 module TalkDecorator : Talk
   def sanitized_abstract: () -> untyped

--- a/sig/generated/decorators/user_decorator.rbs
+++ b/sig/generated/decorators/user_decorator.rbs
@@ -1,3 +1,5 @@
+# Generated from app/decorators/user_decorator.rb with RBS::Inline
+
 # @rbs module-self User
 module UserDecorator : User
   # @rbs return: String

--- a/sig/generated/digested_assets_path_resolver.rbs
+++ b/sig/generated/digested_assets_path_resolver.rbs
@@ -1,3 +1,5 @@
+# Generated from lib/digested_assets_path_resolver.rb with RBS::Inline
+
 class DigestedAssetsPathResolver
   def initialize: () -> untyped
 

--- a/sig/generated/helpers/application_helper.rbs
+++ b/sig/generated/helpers/application_helper.rbs
@@ -1,3 +1,5 @@
+# Generated from app/helpers/application_helper.rb with RBS::Inline
+
 module ApplicationHelper
   def vapid_public_key_bytes: () -> untyped
 

--- a/sig/generated/helpers/home_helper.rbs
+++ b/sig/generated/helpers/home_helper.rbs
@@ -1,2 +1,4 @@
+# Generated from app/helpers/home_helper.rb with RBS::Inline
+
 module HomeHelper
 end

--- a/sig/generated/helpers/profiles_helper.rbs
+++ b/sig/generated/helpers/profiles_helper.rbs
@@ -1,2 +1,4 @@
+# Generated from app/helpers/profiles_helper.rb with RBS::Inline
+
 module ProfilesHelper
 end

--- a/sig/generated/helpers/sessions_helper.rbs
+++ b/sig/generated/helpers/sessions_helper.rbs
@@ -1,3 +1,5 @@
+# Generated from app/helpers/sessions_helper.rb with RBS::Inline
+
 # @rbs module-self ActionController::Base
 module SessionsHelper : ActionController::Base
   class UnauthorizedError < StandardError

--- a/sig/generated/helpers/signage_helper.rbs
+++ b/sig/generated/helpers/signage_helper.rbs
@@ -1,2 +1,4 @@
+# Generated from app/helpers/signage_helper.rb with RBS::Inline
+
 module SignageHelper
 end

--- a/sig/generated/helpers/talks_helper.rbs
+++ b/sig/generated/helpers/talks_helper.rbs
@@ -1,3 +1,5 @@
+# Generated from app/helpers/talks_helper.rb with RBS::Inline
+
 module TalksHelper
   def time_with_zone_to_anchor: (untyped time_with_zone) -> untyped
 end

--- a/sig/generated/jobs/application_job.rbs
+++ b/sig/generated/jobs/application_job.rbs
@@ -1,3 +1,5 @@
+# Generated from app/jobs/application_job.rb with RBS::Inline
+
 class ApplicationJob < ActiveJob::Base
   include _RbsRailsPathHelpers
 end

--- a/sig/generated/jobs/broadcast_announcement_job.rbs
+++ b/sig/generated/jobs/broadcast_announcement_job.rbs
@@ -1,3 +1,5 @@
+# Generated from app/jobs/broadcast_announcement_job.rb with RBS::Inline
+
 class BroadcastAnnouncementJob < ApplicationJob
   def perform: (untyped announcement_id) -> untyped
 end

--- a/sig/generated/jobs/determine_user_role_job.rbs
+++ b/sig/generated/jobs/determine_user_role_job.rbs
@@ -1,3 +1,5 @@
+# Generated from app/jobs/determine_user_role_job.rb with RBS::Inline
+
 class DetermineUserRoleJob < ApplicationJob
   def perform: (untyped user_id) -> untyped
 

--- a/sig/generated/jobs/send_announcement_push_notification_job.rbs
+++ b/sig/generated/jobs/send_announcement_push_notification_job.rbs
@@ -1,3 +1,5 @@
+# Generated from app/jobs/send_announcement_push_notification_job.rb with RBS::Inline
+
 class SendAnnouncementPushNotificationJob < ApplicationJob
   def perform: (untyped announcement_id, untyped message) -> untyped
 end

--- a/sig/generated/jobs/send_talk_reminder_push_notification_job.rbs
+++ b/sig/generated/jobs/send_talk_reminder_push_notification_job.rbs
@@ -1,3 +1,5 @@
+# Generated from app/jobs/send_talk_reminder_push_notification_job.rb with RBS::Inline
+
 class SendTalkReminderPushNotificationJob < ApplicationJob
   def perform: (*untyped args) -> untyped
 end

--- a/sig/generated/mailers/application_mailer.rbs
+++ b/sig/generated/mailers/application_mailer.rbs
@@ -1,2 +1,4 @@
+# Generated from app/mailers/application_mailer.rb with RBS::Inline
+
 class ApplicationMailer < ActionMailer::Base
 end

--- a/sig/generated/models/announcement.rbs
+++ b/sig/generated/models/announcement.rbs
@@ -1,3 +1,5 @@
+# Generated from app/models/announcement.rb with RBS::Inline
+
 class Announcement < ApplicationRecord
   def cannot_change_to_draft_if_published: () -> untyped
 end

--- a/sig/generated/models/application_record.rbs
+++ b/sig/generated/models/application_record.rbs
@@ -1,3 +1,5 @@
+# Generated from app/models/application_record.rb with RBS::Inline
+
 class ApplicationRecord < ActiveRecord::Base
   def current_event: () -> untyped
 end

--- a/sig/generated/models/authentication_provider_email_and_password.rbs
+++ b/sig/generated/models/authentication_provider_email_and_password.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/authentication_provider_email_and_password.rb with RBS::Inline
+
+class AuthenticationProviderEmailAndPassword < ApplicationRecord
+end

--- a/sig/generated/models/authentication_provider_github.rbs
+++ b/sig/generated/models/authentication_provider_github.rbs
@@ -1,3 +1,5 @@
+# Generated from app/models/authentication_provider_github.rb with RBS::Inline
+
 class AuthenticationProviderGithub < ApplicationRecord
   # @rbs auth: untyped
   # @rbs &block: ?(User) -> untyped

--- a/sig/generated/models/cloudflare_stream_live_stream.rbs
+++ b/sig/generated/models/cloudflare_stream_live_stream.rbs
@@ -1,3 +1,5 @@
+# Generated from app/models/cloudflare_stream_live_stream.rb with RBS::Inline
+
 class CloudflareStreamLiveStream < ApplicationRecord
   # @rbs uid: String
   # @rbs return: boolish

--- a/sig/generated/models/event.rbs
+++ b/sig/generated/models/event.rbs
@@ -1,3 +1,5 @@
+# Generated from app/models/event.rb with RBS::Inline
+
 class Event < ApplicationRecord
   ONGOING_EVENT_SLUG: ::String
 

--- a/sig/generated/models/ongoing_event.rbs
+++ b/sig/generated/models/ongoing_event.rbs
@@ -1,3 +1,5 @@
+# Generated from app/models/ongoing_event.rb with RBS::Inline
+
 class OngoingEvent < ApplicationRecord
   def self.count: () -> Integer
 

--- a/sig/generated/models/profile.rbs
+++ b/sig/generated/models/profile.rbs
@@ -1,3 +1,5 @@
+# Generated from app/models/profile.rb with RBS::Inline
+
 class Profile < ApplicationRecord
   # @rbs return: void
   def ensure_image_from_github: () -> void

--- a/sig/generated/models/profile_badge.rbs
+++ b/sig/generated/models/profile_badge.rbs
@@ -1,3 +1,5 @@
+# Generated from app/models/profile_badge.rb with RBS::Inline
+
 class ProfileBadge < ApplicationRecord
   COLOR_CODE_REGEXP: ::Regexp
 end

--- a/sig/generated/models/profile_badges_profile.rbs
+++ b/sig/generated/models/profile_badges_profile.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/profile_badges_profile.rb with RBS::Inline
+
+class ProfileBadgesProfile < ApplicationRecord
+end

--- a/sig/generated/models/profile_exchange.rbs
+++ b/sig/generated/models/profile_exchange.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/profile_exchange.rb with RBS::Inline
+
+class ProfileExchange < ApplicationRecord
+end

--- a/sig/generated/models/signage.rbs
+++ b/sig/generated/models/signage.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/signage.rb with RBS::Inline
+
+class Signage < ApplicationRecord
+end

--- a/sig/generated/models/signage_device.rbs
+++ b/sig/generated/models/signage_device.rbs
@@ -1,3 +1,5 @@
+# Generated from app/models/signage_device.rb with RBS::Inline
+
 class SignageDevice < ApplicationRecord
   def signage_panel: () -> untyped
 end

--- a/sig/generated/models/signage_device_assign.rbs
+++ b/sig/generated/models/signage_device_assign.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/signage_device_assign.rb with RBS::Inline
+
+class SignageDeviceAssign < ApplicationRecord
+end

--- a/sig/generated/models/signage_page.rbs
+++ b/sig/generated/models/signage_page.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/signage_page.rb with RBS::Inline
+
+class SignagePage < ApplicationRecord
+end

--- a/sig/generated/models/signage_panel.rbs
+++ b/sig/generated/models/signage_panel.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/signage_panel.rb with RBS::Inline
+
+class SignagePanel < ApplicationRecord
+end

--- a/sig/generated/models/signage_schedule.rbs
+++ b/sig/generated/models/signage_schedule.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/signage_schedule.rb with RBS::Inline
+
+class SignageSchedule < ApplicationRecord
+end

--- a/sig/generated/models/signage_schedule_assign.rbs
+++ b/sig/generated/models/signage_schedule_assign.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/signage_schedule_assign.rb with RBS::Inline
+
+class SignageScheduleAssign < ApplicationRecord
+end

--- a/sig/generated/models/speaker.rbs
+++ b/sig/generated/models/speaker.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/speaker.rb with RBS::Inline
+
+class Speaker < ApplicationRecord
+end

--- a/sig/generated/models/speakers_talk.rbs
+++ b/sig/generated/models/speakers_talk.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/speakers_talk.rb with RBS::Inline
+
+class SpeakersTalk < ApplicationRecord
+end

--- a/sig/generated/models/talk.rbs
+++ b/sig/generated/models/talk.rbs
@@ -1,3 +1,5 @@
+# Generated from app/models/talk.rb with RBS::Inline
+
 class Talk < ApplicationRecord
   # @rbs user: User
   # @rbs return: bool

--- a/sig/generated/models/talk_bookmark.rbs
+++ b/sig/generated/models/talk_bookmark.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/talk_bookmark.rb with RBS::Inline
+
+class TalkBookmark < ApplicationRecord
+end

--- a/sig/generated/models/talk_reminder.rbs
+++ b/sig/generated/models/talk_reminder.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/talk_reminder.rb with RBS::Inline
+
+class TalkReminder < ApplicationRecord
+end

--- a/sig/generated/models/unread_announcement.rbs
+++ b/sig/generated/models/unread_announcement.rbs
@@ -1,0 +1,4 @@
+# Generated from app/models/unread_announcement.rb with RBS::Inline
+
+class UnreadAnnouncement < ApplicationRecord
+end

--- a/sig/generated/models/user.rbs
+++ b/sig/generated/models/user.rbs
@@ -1,3 +1,5 @@
+# Generated from app/models/user.rb with RBS::Inline
+
 class User < ApplicationRecord
   # @rbs return: bool
   def have_unread_announcements?: () -> bool

--- a/sig/generated/models/webpush_subscription.rbs
+++ b/sig/generated/models/webpush_subscription.rbs
@@ -1,3 +1,5 @@
+# Generated from app/models/webpush_subscription.rb with RBS::Inline
+
 class WebpushSubscription < ApplicationRecord
   def send_webpush!: (untyped message) -> untyped
 end

--- a/sig/generated/resources/signage_device_assign_resource.rbs
+++ b/sig/generated/resources/signage_device_assign_resource.rbs
@@ -1,3 +1,5 @@
+# Generated from app/resources/signage_device_assign_resource.rb with RBS::Inline
+
 class SignageDeviceAssignResource
   include Alba::Resource
 end

--- a/sig/generated/resources/signage_device_resource.rbs
+++ b/sig/generated/resources/signage_device_resource.rbs
@@ -1,3 +1,5 @@
+# Generated from app/resources/signage_device_resource.rb with RBS::Inline
+
 class SignageDeviceResource
   include Alba::Resource
 

--- a/sig/generated/resources/signage_page_resource.rbs
+++ b/sig/generated/resources/signage_page_resource.rbs
@@ -1,3 +1,5 @@
+# Generated from app/resources/signage_page_resource.rb with RBS::Inline
+
 class SignagePageResource
   include Alba::Resource
 

--- a/sig/generated/resources/signage_panel_assign_resource.rbs
+++ b/sig/generated/resources/signage_panel_assign_resource.rbs
@@ -1,3 +1,5 @@
+# Generated from app/resources/signage_panel_assign_resource.rb with RBS::Inline
+
 class SignagePanelAssignResource
   include Alba::Resource
 

--- a/sig/generated/resources/signage_panel_resource.rbs
+++ b/sig/generated/resources/signage_panel_resource.rbs
@@ -1,3 +1,5 @@
+# Generated from app/resources/signage_panel_resource.rb with RBS::Inline
+
 class SignagePanelResource
   include Alba::Resource
 

--- a/sig/generated/resources/signage_resource.rbs
+++ b/sig/generated/resources/signage_resource.rbs
@@ -1,3 +1,5 @@
+# Generated from app/resources/signage_resource.rb with RBS::Inline
+
 class SignageResource
   include Alba::Resource
 

--- a/sig/generated/resources/signage_schedule_assign_resource.rbs
+++ b/sig/generated/resources/signage_schedule_assign_resource.rbs
@@ -1,3 +1,5 @@
+# Generated from app/resources/signage_schedule_assign_resource.rb with RBS::Inline
+
 class SignageScheduleAssignResource
   include Alba::Resource
 

--- a/sig/generated/resources/signage_schedule_resource.rbs
+++ b/sig/generated/resources/signage_schedule_resource.rbs
@@ -1,3 +1,5 @@
+# Generated from app/resources/signage_schedule_resource.rb with RBS::Inline
+
 class SignageScheduleResource
   include Alba::Resource
 

--- a/sig/handwritten/app/models/user.rbs
+++ b/sig/handwritten/app/models/user.rbs
@@ -8,7 +8,9 @@ class User < ApplicationRecord
 
   # User has profile and authentication_provider_github at least one
   def profile: () -> Profile
+             | ...
   def authentication_provider_github: () -> AuthenticationProviderGithub
+                                    | ...
 
   class ActiveRecord_Relation
     # NOTE: Added by kaminari

--- a/sig/rbs_rails/app/models/announcement.rbs
+++ b/sig/rbs_rails/app/models/announcement.rbs
@@ -1,4 +1,6 @@
 class Announcement < ::ApplicationRecord
+  extend _ActiveRecord_Relation_ClassMethods[Announcement, ActiveRecord_Relation, Integer]
+
   module GeneratedAttributeMethods
     def id: () -> Integer
 
@@ -252,25 +254,6 @@ class Announcement < ::ApplicationRecord
 
     def clear_title_change: () -> void
   end
-
-  module GeneratedAssociationMethods
-  end
-
-  module GeneratedRelationMethods
-  end
-
-  class ActiveRecord_Relation < ::ActiveRecord::Relation
-    include GeneratedRelationMethods
-    include _ActiveRecord_Relation[Announcement, Integer]
-    include Enumerable[Announcement]
-  end
-
-  class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-    include GeneratedRelationMethods
-    include _ActiveRecord_Relation[Announcement, Integer]
-  end
-  extend _ActiveRecord_Relation_ClassMethods[Announcement, ActiveRecord_Relation, Integer]
-
   include GeneratedAttributeMethods
 
   def rich_text_content: () -> ActionText::RichText?
@@ -285,6 +268,21 @@ class Announcement < ::ApplicationRecord
   def build_event: (untyped) -> Event
   def create_event: (untyped) -> Event
   def create_event!: (untyped) -> Event
-
+  module GeneratedAssociationMethods
+  end
   include GeneratedAssociationMethods
+
+  module GeneratedRelationMethods
+  end
+
+  class ActiveRecord_Relation < ::ActiveRecord::Relation
+    include GeneratedRelationMethods
+    include _ActiveRecord_Relation[Announcement, Integer]
+    include Enumerable[Announcement]
+  end
+
+  class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+    include GeneratedRelationMethods
+    include _ActiveRecord_Relation[Announcement, Integer]
+  end
 end

--- a/sig/rbs_rails/app/models/talk.rbs
+++ b/sig/rbs_rails/app/models/talk.rbs
@@ -1,4 +1,6 @@
 class Talk < ::ApplicationRecord
+  extend _ActiveRecord_Relation_ClassMethods[Talk, ActiveRecord_Relation, Integer]
+
   module GeneratedAttributeMethods
     def id: () -> Integer
 
@@ -324,25 +326,6 @@ class Talk < ::ApplicationRecord
 
     def clear_track_change: () -> void
   end
-
-  module GeneratedAssociationMethods
-  end
-
-  module GeneratedRelationMethods
-  end
-
-  class ActiveRecord_Relation < ::ActiveRecord::Relation
-    include GeneratedRelationMethods
-    include _ActiveRecord_Relation[Talk, Integer]
-    include Enumerable[Talk]
-  end
-
-  class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-    include GeneratedRelationMethods
-    include _ActiveRecord_Relation[Talk, Integer]
-  end
-  extend _ActiveRecord_Relation_ClassMethods[Talk, ActiveRecord_Relation, Integer]
-
   include GeneratedAttributeMethods
   def speakers_talks: () -> SpeakersTalk::ActiveRecord_Associations_CollectionProxy
   def speakers_talks=: (SpeakersTalk::ActiveRecord_Associations_CollectionProxy | Array[SpeakersTalk]) -> (SpeakersTalk::ActiveRecord_Associations_CollectionProxy | Array[SpeakersTalk])
@@ -367,6 +350,21 @@ class Talk < ::ApplicationRecord
   def build_event: (untyped) -> Event
   def create_event: (untyped) -> Event
   def create_event!: (untyped) -> Event
-
+  module GeneratedAssociationMethods
+  end
   include GeneratedAssociationMethods
+
+  module GeneratedRelationMethods
+  end
+
+  class ActiveRecord_Relation < ::ActiveRecord::Relation
+    include GeneratedRelationMethods
+    include _ActiveRecord_Relation[Talk, Integer]
+    include Enumerable[Talk]
+  end
+
+  class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+    include GeneratedRelationMethods
+    include _ActiveRecord_Relation[Talk, Integer]
+  end
 end

--- a/sig/rbs_rails/app/models/user.rbs
+++ b/sig/rbs_rails/app/models/user.rbs
@@ -1,4 +1,6 @@
 class User < ::ApplicationRecord
+  extend _ActiveRecord_Relation_ClassMethods[User, ActiveRecord_Relation, Integer]
+
   module GeneratedAttributeMethods
     def id: () -> Integer
 
@@ -180,25 +182,6 @@ class User < ::ApplicationRecord
 
     def clear_updated_at_change: () -> void
   end
-
-  module GeneratedAssociationMethods
-  end
-
-  module GeneratedRelationMethods
-  end
-
-  class ActiveRecord_Relation < ::ActiveRecord::Relation
-    include GeneratedRelationMethods
-    include _ActiveRecord_Relation[User, Integer]
-    include Enumerable[User]
-  end
-
-  class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-    include GeneratedRelationMethods
-    include _ActiveRecord_Relation[User, Integer]
-  end
-  extend _ActiveRecord_Relation_ClassMethods[User, ActiveRecord_Relation, Integer]
-
   include GeneratedAttributeMethods
   def webpush_subscriptions: () -> WebpushSubscription::ActiveRecord_Associations_CollectionProxy
   def webpush_subscriptions=: (WebpushSubscription::ActiveRecord_Associations_CollectionProxy | Array[WebpushSubscription]) -> (WebpushSubscription::ActiveRecord_Associations_CollectionProxy | Array[WebpushSubscription])
@@ -224,7 +207,7 @@ class User < ::ApplicationRecord
   def talk_reminders=: (TalkReminder::ActiveRecord_Associations_CollectionProxy | Array[TalkReminder]) -> (TalkReminder::ActiveRecord_Associations_CollectionProxy | Array[TalkReminder])
   def talk_reminder_ids: () -> Array[Integer]
   def talk_reminder_ids=: (Array[Integer]) -> Array[Integer]
-
+  def authentication_provider_github: () -> AuthenticationProviderGithub?
   def authentication_provider_github=: (AuthenticationProviderGithub?) -> AuthenticationProviderGithub?
   def build_authentication_provider_github: (untyped) -> AuthenticationProviderGithub
   def create_authentication_provider_github: (untyped) -> AuthenticationProviderGithub
@@ -236,12 +219,28 @@ class User < ::ApplicationRecord
   def create_authentication_provider_email_and_password: (untyped) -> AuthenticationProviderEmailAndPassword
   def create_authentication_provider_email_and_password!: (untyped) -> AuthenticationProviderEmailAndPassword
   def reload_authentication_provider_email_and_password: () -> AuthenticationProviderEmailAndPassword?
-
+  def profile: () -> Profile?
   def profile=: (Profile?) -> Profile?
   def build_profile: (untyped) -> Profile
   def create_profile: (untyped) -> Profile
   def create_profile!: (untyped) -> Profile
   def reload_profile: () -> Profile?
 
+  module GeneratedAssociationMethods
+  end
   include GeneratedAssociationMethods
+
+  module GeneratedRelationMethods
+  end
+
+  class ActiveRecord_Relation < ::ActiveRecord::Relation
+    include GeneratedRelationMethods
+    include _ActiveRecord_Relation[User, Integer]
+    include Enumerable[User]
+  end
+
+  class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+    include GeneratedRelationMethods
+    include _ActiveRecord_Relation[User, Integer]
+  end
 end

--- a/sig/rbs_rails/model_dependencies.rbs
+++ b/sig/rbs_rails/model_dependencies.rbs
@@ -14,7 +14,8 @@ class SolidQueue::Process::ActiveRecord_Associations_CollectionProxy < ActiveRec
 end
 class SolidQueue::Execution < SolidQueue::Record
 end
-
+module ActiveStorage
+end
 class ActiveStorage::Record < ActiveRecord::Base
 end
 class ActiveStorage::VariantRecord::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy

--- a/sig/rbs_rails/model_dependencies.rbs
+++ b/sig/rbs_rails/model_dependencies.rbs
@@ -1,3 +1,5 @@
+module ActionText
+end
 class ActionText::Record < ActiveRecord::Base
 end
 class ActiveStorage::Attachment::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy

--- a/sig/rbs_rails/path_helpers.rbs
+++ b/sig/rbs_rails/path_helpers.rbs
@@ -1,465 +1,234 @@
 interface _RbsRailsPathHelpers
   def rails_mailers_path: (*untyped) -> String
-
   def rails_info_properties_path: (*untyped) -> String
-
   def rails_info_routes_path: (*untyped) -> String
-
   def rails_info_notes_path: (*untyped) -> String
-
   def rails_info_path: (*untyped) -> String
-
   def admin_mission_control_jobs_path: (*untyped) -> String
-
   def root_path: (*untyped) -> String
-
   def login_path: (*untyped) -> String
-
   def logout_path: (*untyped) -> String
-
   def service_worker_path: (*untyped) -> String
-
   def pwa_manifest_path: (*untyped) -> String
-
   def setting_path: (*untyped) -> String
-
   def webpush_subscription_path: (*untyped) -> String
-
   def sample_webpush_notifications_path: (*untyped) -> String
-
   def profile_profile_image_path: (*untyped) -> String
-
   def profiles_path: (*untyped) -> String
-
   def new_profile_path: (*untyped) -> String
-
   def edit_profile_path: (*untyped) -> String
-
   def profile_path: (*untyped) -> String
-
   def profile_badges_path: (*untyped) -> String
-
   def new_profile_badge_path: (*untyped) -> String
-
   def user_path: (*untyped) -> String
-
   def talk_bookmarks_path: (*untyped) -> String
-
   def talk_bookmark_path: (*untyped) -> String
-
   def unread_announcement_path: (*untyped) -> String
-
   def about_path: (*untyped) -> String
-
   def live_stream_path: (*untyped) -> String
-
   def signages_path: (*untyped) -> String
-
   def signage_devices_path: (*untyped) -> String
-
   def admin_events_path: (*untyped) -> String
-
   def new_admin_event_path: (*untyped) -> String
-
   def edit_admin_event_path: (*untyped) -> String
-
   def admin_event_path: (*untyped) -> String
-
   def admin_ongoing_events_path: (*untyped) -> String
-
   def admin_ongoing_event_path: (*untyped) -> String
-
   def admin_users_path: (*untyped) -> String
-
   def new_admin_user_path: (*untyped) -> String
-
   def edit_admin_user_path: (*untyped) -> String
-
   def admin_user_path: (*untyped) -> String
-
   def admin_profile_profile_badges_profiles_path: (*untyped) -> String
-
   def new_admin_profile_profile_badges_profile_path: (*untyped) -> String
-
   def admin_profile_path: (*untyped) -> String
-
   def admin_talks_path: (*untyped) -> String
-
   def edit_admin_talk_path: (*untyped) -> String
-
   def admin_talk_path: (*untyped) -> String
-
   def admin_announcements_path: (*untyped) -> String
-
   def new_admin_announcement_path: (*untyped) -> String
-
   def edit_admin_announcement_path: (*untyped) -> String
-
   def admin_announcement_path: (*untyped) -> String
-
   def admin_profile_badges_path: (*untyped) -> String
-
   def new_admin_profile_badge_path: (*untyped) -> String
-
   def edit_admin_profile_badge_path: (*untyped) -> String
-
   def admin_profile_badge_path: (*untyped) -> String
-
   def admin_live_streams_path: (*untyped) -> String
-
   def new_admin_live_stream_path: (*untyped) -> String
-
   def admin_live_stream_path: (*untyped) -> String
-
   def admin_signages_path: (*untyped) -> String
-
   def new_admin_signage_path: (*untyped) -> String
-
   def admin_signage_path: (*untyped) -> String
-
   def admin_signage_schedules_path: (*untyped) -> String
-
   def new_admin_signage_schedule_path: (*untyped) -> String
-
   def edit_admin_signage_schedule_path: (*untyped) -> String
-
   def admin_signage_schedule_path: (*untyped) -> String
-
   def admin_signage_schedule_assigns_path: (*untyped) -> String
-
   def new_admin_signage_schedule_assign_path: (*untyped) -> String
-
   def admin_signage_schedule_assign_path: (*untyped) -> String
-
   def admin_signage_panels_path: (*untyped) -> String
-
   def new_admin_signage_panel_path: (*untyped) -> String
-
   def edit_admin_signage_panel_path: (*untyped) -> String
-
   def admin_signage_panel_path: (*untyped) -> String
-
   def admin_signage_devices_path: (*untyped) -> String
-
   def new_admin_signage_device_path: (*untyped) -> String
-
   def edit_admin_signage_device_path: (*untyped) -> String
-
   def admin_signage_device_path: (*untyped) -> String
-
   def admin_signage_device_assigns_path: (*untyped) -> String
-
   def new_admin_signage_device_assign_path: (*untyped) -> String
-
   def admin_signage_device_assign_path: (*untyped) -> String
-
   def admin_signage_pages_path: (*untyped) -> String
-
   def new_admin_signage_page_path: (*untyped) -> String
-
   def edit_admin_signage_page_path: (*untyped) -> String
-
   def admin_signage_page_path: (*untyped) -> String
-
   def admin_path: (*untyped) -> String
-
   def operators_path: (*untyped) -> String
-
   def rails_health_check_path: (*untyped) -> String
-
   def event_path: (*untyped) -> String
-
   def event_talks_path: (*untyped) -> String
-
   def event_talk_path: (*untyped) -> String
-
   def event_announcements_path: (*untyped) -> String
-
   def event_announcement_path: (*untyped) -> String
-
   def turbo_recede_historical_location_path: (*untyped) -> String
-
   def turbo_resume_historical_location_path: (*untyped) -> String
-
   def turbo_refresh_historical_location_path: (*untyped) -> String
-
   def rails_postmark_inbound_emails_path: (*untyped) -> String
-
   def rails_relay_inbound_emails_path: (*untyped) -> String
-
   def rails_sendgrid_inbound_emails_path: (*untyped) -> String
-
   def rails_mandrill_inbound_health_check_path: (*untyped) -> String
-
   def rails_mandrill_inbound_emails_path: (*untyped) -> String
-
   def rails_mailgun_inbound_emails_path: (*untyped) -> String
-
   def rails_conductor_inbound_emails_path: (*untyped) -> String
-
   def new_rails_conductor_inbound_email_path: (*untyped) -> String
-
   def rails_conductor_inbound_email_path: (*untyped) -> String
-
   def new_rails_conductor_inbound_email_source_path: (*untyped) -> String
-
   def rails_conductor_inbound_email_sources_path: (*untyped) -> String
-
   def rails_conductor_inbound_email_reroute_path: (*untyped) -> String
-
   def rails_conductor_inbound_email_incinerate_path: (*untyped) -> String
-
   def rails_service_blob_path: (*untyped) -> String
-
   def rails_service_blob_proxy_path: (*untyped) -> String
-
   def rails_blob_representation_path: (*untyped) -> String
-
   def rails_blob_representation_proxy_path: (*untyped) -> String
-
   def rails_disk_service_path: (*untyped) -> String
-
   def update_rails_disk_service_path: (*untyped) -> String
-
   def rails_direct_uploads_path: (*untyped) -> String
-
   def rails_representation_path: (*untyped) -> String
-
   def rails_blob_path: (*untyped) -> String
-
   def rails_storage_proxy_path: (*untyped) -> String
-
   def rails_storage_redirect_path: (*untyped) -> String
-
   def rails_mailers_url: (*untyped) -> String
-
   def rails_info_properties_url: (*untyped) -> String
-
   def rails_info_routes_url: (*untyped) -> String
-
   def rails_info_notes_url: (*untyped) -> String
-
   def rails_info_url: (*untyped) -> String
-
   def admin_mission_control_jobs_url: (*untyped) -> String
-
   def root_url: (*untyped) -> String
-
   def login_url: (*untyped) -> String
-
   def logout_url: (*untyped) -> String
-
   def service_worker_url: (*untyped) -> String
-
   def pwa_manifest_url: (*untyped) -> String
-
   def setting_url: (*untyped) -> String
-
   def webpush_subscription_url: (*untyped) -> String
-
   def sample_webpush_notifications_url: (*untyped) -> String
-
   def profile_profile_image_url: (*untyped) -> String
-
   def profiles_url: (*untyped) -> String
-
   def new_profile_url: (*untyped) -> String
-
   def edit_profile_url: (*untyped) -> String
-
   def profile_url: (*untyped) -> String
-
   def profile_badges_url: (*untyped) -> String
-
   def new_profile_badge_url: (*untyped) -> String
-
   def user_url: (*untyped) -> String
-
   def talk_bookmarks_url: (*untyped) -> String
-
   def talk_bookmark_url: (*untyped) -> String
-
   def unread_announcement_url: (*untyped) -> String
-
   def about_url: (*untyped) -> String
-
   def live_stream_url: (*untyped) -> String
-
   def signages_url: (*untyped) -> String
-
   def signage_devices_url: (*untyped) -> String
-
   def admin_events_url: (*untyped) -> String
-
   def new_admin_event_url: (*untyped) -> String
-
   def edit_admin_event_url: (*untyped) -> String
-
   def admin_event_url: (*untyped) -> String
-
   def admin_ongoing_events_url: (*untyped) -> String
-
   def admin_ongoing_event_url: (*untyped) -> String
-
   def admin_users_url: (*untyped) -> String
-
   def new_admin_user_url: (*untyped) -> String
-
   def edit_admin_user_url: (*untyped) -> String
-
   def admin_user_url: (*untyped) -> String
-
   def admin_profile_profile_badges_profiles_url: (*untyped) -> String
-
   def new_admin_profile_profile_badges_profile_url: (*untyped) -> String
-
   def admin_profile_url: (*untyped) -> String
-
   def admin_talks_url: (*untyped) -> String
-
   def edit_admin_talk_url: (*untyped) -> String
-
   def admin_talk_url: (*untyped) -> String
-
   def admin_announcements_url: (*untyped) -> String
-
   def new_admin_announcement_url: (*untyped) -> String
-
   def edit_admin_announcement_url: (*untyped) -> String
-
   def admin_announcement_url: (*untyped) -> String
-
   def admin_profile_badges_url: (*untyped) -> String
-
   def new_admin_profile_badge_url: (*untyped) -> String
-
   def edit_admin_profile_badge_url: (*untyped) -> String
-
   def admin_profile_badge_url: (*untyped) -> String
-
   def admin_live_streams_url: (*untyped) -> String
-
   def new_admin_live_stream_url: (*untyped) -> String
-
   def admin_live_stream_url: (*untyped) -> String
-
   def admin_signages_url: (*untyped) -> String
-
   def new_admin_signage_url: (*untyped) -> String
-
   def admin_signage_url: (*untyped) -> String
-
   def admin_signage_schedules_url: (*untyped) -> String
-
   def new_admin_signage_schedule_url: (*untyped) -> String
-
   def edit_admin_signage_schedule_url: (*untyped) -> String
-
   def admin_signage_schedule_url: (*untyped) -> String
-
   def admin_signage_schedule_assigns_url: (*untyped) -> String
-
   def new_admin_signage_schedule_assign_url: (*untyped) -> String
-
   def admin_signage_schedule_assign_url: (*untyped) -> String
-
   def admin_signage_panels_url: (*untyped) -> String
-
   def new_admin_signage_panel_url: (*untyped) -> String
-
   def edit_admin_signage_panel_url: (*untyped) -> String
-
   def admin_signage_panel_url: (*untyped) -> String
-
   def admin_signage_devices_url: (*untyped) -> String
-
   def new_admin_signage_device_url: (*untyped) -> String
-
   def edit_admin_signage_device_url: (*untyped) -> String
-
   def admin_signage_device_url: (*untyped) -> String
-
   def admin_signage_device_assigns_url: (*untyped) -> String
-
   def new_admin_signage_device_assign_url: (*untyped) -> String
-
   def admin_signage_device_assign_url: (*untyped) -> String
-
   def admin_signage_pages_url: (*untyped) -> String
-
   def new_admin_signage_page_url: (*untyped) -> String
-
   def edit_admin_signage_page_url: (*untyped) -> String
-
   def admin_signage_page_url: (*untyped) -> String
-
   def admin_url: (*untyped) -> String
-
   def operators_url: (*untyped) -> String
-
   def rails_health_check_url: (*untyped) -> String
-
   def event_url: (*untyped) -> String
-
   def event_talks_url: (*untyped) -> String
-
   def event_talk_url: (*untyped) -> String
-
   def event_announcements_url: (*untyped) -> String
-
   def event_announcement_url: (*untyped) -> String
-
   def turbo_recede_historical_location_url: (*untyped) -> String
-
   def turbo_resume_historical_location_url: (*untyped) -> String
-
   def turbo_refresh_historical_location_url: (*untyped) -> String
-
   def rails_postmark_inbound_emails_url: (*untyped) -> String
-
   def rails_relay_inbound_emails_url: (*untyped) -> String
-
   def rails_sendgrid_inbound_emails_url: (*untyped) -> String
-
   def rails_mandrill_inbound_health_check_url: (*untyped) -> String
-
   def rails_mandrill_inbound_emails_url: (*untyped) -> String
-
   def rails_mailgun_inbound_emails_url: (*untyped) -> String
-
   def rails_conductor_inbound_emails_url: (*untyped) -> String
-
   def new_rails_conductor_inbound_email_url: (*untyped) -> String
-
   def rails_conductor_inbound_email_url: (*untyped) -> String
-
   def new_rails_conductor_inbound_email_source_url: (*untyped) -> String
-
   def rails_conductor_inbound_email_sources_url: (*untyped) -> String
-
   def rails_conductor_inbound_email_reroute_url: (*untyped) -> String
-
   def rails_conductor_inbound_email_incinerate_url: (*untyped) -> String
-
   def rails_service_blob_url: (*untyped) -> String
-
   def rails_service_blob_proxy_url: (*untyped) -> String
-
   def rails_blob_representation_url: (*untyped) -> String
-
   def rails_blob_representation_proxy_url: (*untyped) -> String
-
   def rails_disk_service_url: (*untyped) -> String
-
   def update_rails_disk_service_url: (*untyped) -> String
-
   def rails_direct_uploads_url: (*untyped) -> String
-
   def rails_representation_url: (*untyped) -> String
-
   def rails_blob_url: (*untyped) -> String
-
   def rails_storage_proxy_url: (*untyped) -> String
-
   def rails_storage_redirect_url: (*untyped) -> String
 end

--- a/sig/shims/activestorage.rbs
+++ b/sig/shims/activestorage.rbs
@@ -1,6 +1,0 @@
-module ActiveStorage
-  class Current < ActiveSupport::CurrentAttributes
-    def self.url_options: () -> untyped
-    def self.url_options=: (untyped) -> untyped
-  end
-end

--- a/sig/shims/alba.rbs
+++ b/sig/shims/alba.rbs
@@ -2,19 +2,27 @@ module Alba
   module Resource
     module InstanceMethods
       def initialize: (untyped object, ?params: Hash[untyped, untyped], ?within: untyped) -> void
+
       def serialize: (?root_key: untyped, ?meta: Hash[untyped, untyped]) -> String
+
       def serializable_hash: () -> Hash[untyped, untyped]
+
       alias to_h serializable_hash
     end
 
     module ClassMethods
       def attributes: (*untyped attrs, ?if: untyped, **untyped attrs_with_types) -> untyped
+
       def attribute: (untyped name, **untyped options) { (?) -> untyped } -> untyped
 
       def association: (untyped name, ?untyped condition, ?resource: untyped, ?key: untyped, ?params: Hash[untyped, untyped], **untyped options) ?{ (?) -> untyped } -> untyped
+
       alias one association
+
       alias many association
+
       alias has_one association
+
       alias has_many association
     end
 

--- a/sig/shims/commonmarker.rbs
+++ b/sig/shims/commonmarker.rbs
@@ -1,3 +1,0 @@
-module Commonmarker
-  def self.to_html: (String text, ?Hash[untyped, untyped] options, ?Hash[untyped, untyped] plugins) -> String
-end

--- a/sig/shims/rails-html-sanitizer.rbs
+++ b/sig/shims/rails-html-sanitizer.rbs
@@ -1,9 +1,0 @@
-module Rails
-  module HTML
-    class SafeListSanitizer
-      def sanitize: (String html, untyped options) -> String
-    end
-  end
-
-  module Html = HTML
-end


### PR DESCRIPTION
Now we completed the migration to RBS::Inline from "rbs prototype" and
handwritten types.  It's time to make RBS files under `sig/generated/`
primary.

In "rbs prototype" era, our types were conflicted.  But, after the
migration, they are not conflicted.

Therefore this stops subtracting types from each other.

Note: This contains https://github.com/kaigionrails/conference-app/pull/362.