### PR TITLE
Add border to admin form inputs

### DIFF
--- a/app/views/admin/announcements/edit.html.erb
+++ b/app/views/admin/announcements/edit.html.erb
@@ -3,11 +3,11 @@
   <%= form_with model: @announcement, url: admin_announcement_path(@announcement), method: :patch do |f| %>
     <%= f.hidden_field :event_id, value: @announcement.event.id %>
     <%= f.label :title, "announce title", class: "block text-lg font-bold mb-2" %>
-    <%= f.text_field :title, class: "block rounded-sm mb-4 w-[40rem]" %>
+    <%= f.text_field :title, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[40rem]" %>
     <%= f.label :content, "announce content", class: "block text-lg font-bold mb-2" %>
     <%= f.rich_text_area :content, class: "block mb-4" %>
     <%= f.label :status, "announce content", class: "block text-lg font-bold mb-2" %>
-    <%= f.select :status, Announcement.statuses, {}, class: "block rounded-sm border-1 cursor-pointer disabled:bg-gray-200 disabled:cursor-not-allowed mb-8", disabled: @announcement.published? %>
+    <%= f.select :status, Announcement.statuses, {}, class: "block rounded-sm border-1 border-gray-400 cursor-pointer disabled:bg-gray-200 disabled:cursor-not-allowed mb-8", disabled: @announcement.published? %>
     <%= f.submit class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
   <% end %>
 </div>

--- a/app/views/admin/announcements/new.html.erb
+++ b/app/views/admin/announcements/new.html.erb
@@ -3,7 +3,7 @@
   <%= form_with model: @announcement, url: admin_announcements_path, method: :post do |f| %>
     <%= f.hidden_field :event_id, value: @announcement.event.id %>
     <%= f.label :title, "announce title", class: "block text-lg font-bold mb-2" %>
-    <%= f.text_field :title, class: "block rounded-sm mb-4 w-[40rem]" %>
+    <%= f.text_field :title, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[40rem]" %>
     <%= f.label :content, "announce content", class: "block text-lg font-bold mb-2" %>
     <%= f.rich_text_area :content, class: "block mb-4" %>
     <%= f.submit class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -1,9 +1,9 @@
 <%= form.label :name, "Name", class: "block text-lg font-bold mb-2" %>
-<%= form.text_field :name, class: "block rounded-sm mb-4 w-[40rem]" %>
+<%= form.text_field :name, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[40rem]" %>
 <%= form.label :slug, "Slug", class: "block text-lg font-bold mb-2" %>
-<%= form.text_field :slug, class: "block rounded-sm mb-4 w-[40rem]" %>
+<%= form.text_field :slug, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[40rem]" %>
 <%= form.label :start_date_jst, "Start date (JST)", class: "block text-lg font-bold mb-2" %>
-<%= form.date_field :start_date_jst, value: event.start_date&.in_time_zone("Tokyo"), class: "block rounded-sm mb-4 w-[40rem]" %>
+<%= form.date_field :start_date_jst, value: event.start_date&.in_time_zone("Tokyo"), class: "block rounded-sm border-1 border-gray-400 mb-4 w-[40rem]" %>
 <%= form.label :end_date_jst, "End date (JST)", class: "block text-lg font-bold mb-2" %>
-<%= form.date_field :end_date_jst, value: event.end_date&.in_time_zone("Tokyo"), class: "block rounded-sm mb-4 w-[40rem]" %>
+<%= form.date_field :end_date_jst, value: event.end_date&.in_time_zone("Tokyo"), class: "block rounded-sm border-1 border-gray-400 mb-4 w-[40rem]" %>
 <%= form.submit class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>

--- a/app/views/admin/live_streams/new.html.erb
+++ b/app/views/admin/live_streams/new.html.erb
@@ -3,7 +3,7 @@
   <div class="mb-8">
     <%= form_with model: @cloudflare_stream_live_stream, url: admin_live_streams_path do |f| %>
       <%= f.label :uid, "uid", class: "block text-lg font-bold mb-2" %>
-      <%= f.text_field :uid, class: "block rounded-sm mb-4 w-[40rem]" %>
+      <%= f.text_field :uid, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[40rem]" %>
       <%= f.submit "Create", class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
     <% end %>
   </div>

--- a/app/views/admin/profile_badges/edit.html.erb
+++ b/app/views/admin/profile_badges/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="mb-8">
     <%= form_with model: @profile_badge, url: admin_profile_badge_path(@profile_badge), method: :patch do |f| %>
       <%= f.label :text, "badge text", class: "block text-lg font-bold mb-2" %>
-      <%= f.text_field :text, class: "block rounded-sm mb-4 w-[40rem]", data: { action: "admin--profile-badge#updatePreview" } %>
+      <%= f.text_field :text, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[40rem]", data: { action: "admin--profile-badge#updatePreview" } %>
       <%= f.label :border_color_code, "border color code", class: "block text-lg font-bold mb-2" %>
       <%= f.color_field :border_color_code, class: "block mb-4", data: { action: "admin--profile-badge#updatePreview" } %>
       <%= f.label :background_color_code, "background color code", class: "block text-lg font-bold mb-2" %>

--- a/app/views/admin/profile_badges/new.html.erb
+++ b/app/views/admin/profile_badges/new.html.erb
@@ -5,7 +5,7 @@
   <div class="mb-8">
     <%= form_with model: @profile_badge, url: admin_profile_badges_path, method: :post do |f| %>
       <%= f.label :text, "badge text", class: "block text-lg font-bold mb-2" %>
-      <%= f.text_field :text, class: "block rounded-sm mb-4 w-[40rem]", data: { action: "admin--profile-badge#updatePreview" } %>
+      <%= f.text_field :text, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[40rem]", data: { action: "admin--profile-badge#updatePreview" } %>
       <%= f.label :border_color_code, "border color code", class: "block text-lg font-bold mb-2" %>
       <%= f.color_field :border_color_code, class: "block mb-4", data: { action: "admin--profile-badge#updatePreview" } %>
       <%= f.label :background_color_code, "background color code", class: "block text-lg font-bold mb-2" %>

--- a/app/views/admin/signage_device_assigns/new.html.erb
+++ b/app/views/admin/signage_device_assigns/new.html.erb
@@ -2,9 +2,9 @@
 <div>
   <%= form_with model: @signage_device_assign, url: admin_signage_device_assigns_path do |f| %>
     <%= f.label :signage_device_id, "device", class: "block text-lg font-bold mb-2" %>
-    <%= f.select :signage_device_id, @signage_devices.map {|device| [device.device_name, device.id]}, {}, class: "block rounded-sm mb-4" %>
+    <%= f.select :signage_device_id, @signage_devices.map {|device| [device.device_name, device.id]}, {}, class: "block rounded-sm border-1 border-gray-400 mb-4" %>
     <%= f.label :signage_panel_id, "表示する面", class: "block text-lg font-bold mb-2" %>
-    <%= f.select :signage_panel_id, @signage_panels.map {|panel| [panel.name, panel.id]}, {}, class: "block rounded-sm mb-4" %>
+    <%= f.select :signage_panel_id, @signage_panels.map {|panel| [panel.name, panel.id]}, {}, class: "block rounded-sm border-1 border-gray-400 mb-4" %>
     <%= f.submit "Create", class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
   <% end %>
 </div>

--- a/app/views/admin/signage_devices/new.html.erb
+++ b/app/views/admin/signage_devices/new.html.erb
@@ -2,7 +2,7 @@
 <div>
   <%= form_with model: @signage_device, url: admin_signage_devices_path do |f| %>
     <%= f.label :device_name, "名前", class: "block text-lg font-bold mb-2" %>
-    <%= f.text_field :device_name, class: "block rounded-sm mb-4 w-52" %>
+    <%= f.text_field :device_name, class: "block rounded-sm border-1 border-gray-400 mb-4 w-52" %>
     <%= f.submit "Create device", class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
   <% end %>
 </div>

--- a/app/views/admin/signage_pages/new.html.erb
+++ b/app/views/admin/signage_pages/new.html.erb
@@ -2,13 +2,13 @@
 <div>
   <%= form_with model: @signage_page, url: admin_signage_pages_path do |f| %>
     <%= f.label :signage_schedule_id, "表示する時間帯", class: "block text-lg font-bold mb-2" %>
-    <%= f.select :signage_schedule_id, @signage_schedules.map {|schedule| ["#{schedule.start_at}～#{schedule.end_at}", schedule.id]}, {}, class: "block rounded-sm mb-4" %>
+    <%= f.select :signage_schedule_id, @signage_schedules.map {|schedule| ["#{schedule.start_at}～#{schedule.end_at}", schedule.id]}, {}, class: "block rounded-sm border-1 border-gray-400 mb-4" %>
     <%= f.label :page_image, "表示する画像", class: "block text-lg font-bold mb-2" %>
     <%= f.file_field :page_image, class: "block mb-4" %>
     <%= f.label :duration_seconds, "表示する秒数", class: "block text-lg font-bold mb-2" %>
-    <%= f.number_field :duration_second, value: 6, class: "block rounded-sm mb-4" %>
+    <%= f.number_field :duration_second, value: 6, class: "block rounded-sm border-1 border-gray-400 mb-4" %>
     <%= f.label :order, "表示順", class: "block text-lg font-bold mb-2" %>
-    <%= f.number_field :order, value: 1, class: "block rounded-sm mb-4" %>
+    <%= f.number_field :order, value: 1, class: "block rounded-sm border-1 border-gray-400 mb-4" %>
     <%= f.submit "Create", class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
   <% end %>
 </div>

--- a/app/views/admin/signage_panels/edit.html.erb
+++ b/app/views/admin/signage_panels/edit.html.erb
@@ -2,7 +2,7 @@
 <div>
   <%= form_with model: @signage_panel, url: admin_signage_panel_path(@signage_panel.id) do |f| %>
     <%= f.label :name, "名前", class: "block text-lg font-bold mb-2" %>
-    <%= f.text_field :name, class: "block rounded-sm mb-4 w-52" %>
+    <%= f.text_field :name, class: "block rounded-sm border-1 border-gray-400 mb-4 w-52" %>
     <%= f.submit "Update panel", class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
   <% end %>
 </div>

--- a/app/views/admin/signage_panels/new.html.erb
+++ b/app/views/admin/signage_panels/new.html.erb
@@ -2,7 +2,7 @@
 <div>
   <%= form_with model: @signage_panel, url: admin_signage_panels_path do |f| %>
     <%= f.label :name, "名前", class: "block text-lg font-bold mb-2" %>
-    <%= f.text_field :name, class: "block rounded-sm mb-4 w-52" %>
+    <%= f.text_field :name, class: "block rounded-sm border-1 border-gray-400 mb-4 w-52" %>
     <%= f.submit "Create panel", class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
   <% end %>
 </div>

--- a/app/views/admin/signage_schedule_assigns/new.html.erb
+++ b/app/views/admin/signage_schedule_assigns/new.html.erb
@@ -2,9 +2,9 @@
 <div>
   <%= form_with model: @signage_schedule_assign, url: admin_signage_schedule_assigns_path do |f| %>
     <%= f.label :signage_schedule_id, "表示する時間帯", class: "block text-lg font-bold mb-2" %>
-    <%= f.select :signage_schedule_id, @signage_schedules.map {|schedule| ["id: #{schedule.id} #{schedule.start_at}～#{schedule.end_at}", schedule.id]}, {}, class: "block rounded-sm mb-4" %>
+    <%= f.select :signage_schedule_id, @signage_schedules.map {|schedule| ["id: #{schedule.id} #{schedule.start_at}～#{schedule.end_at}", schedule.id]}, {}, class: "block rounded-sm border-1 border-gray-400 mb-4" %>
     <%= f.label :signage_panel_id, "表示する面", class: "block text-lg font-bold mb-2" %>
-    <%= f.select :signage_panel_id, @signage_panels.map {|panel| [panel.name, panel.id]}, {}, class: "block rounded-sm mb-4" %>
+    <%= f.select :signage_panel_id, @signage_panels.map {|panel| [panel.name, panel.id]}, {}, class: "block rounded-sm border-1 border-gray-400 mb-4" %>
     <%= f.submit "Create", class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
   <% end %>
 </div>

--- a/app/views/admin/signage_schedules/edit.html.erb
+++ b/app/views/admin/signage_schedules/edit.html.erb
@@ -2,8 +2,8 @@
 <%= form_with model: @signage_schedule, url: admin_signage_schedule_path(@signage_schedule) do |f| %>
   <%= f.hidden_field :signage_id, value: @signage_schedule.signage_id %>
   <%= f.label :start_at, "開始時刻", class: "block text-lg font-bold mb-2" %>
-  <%= f.datetime_field :start_at, value: @signage_schedule.start_at.in_time_zone("Tokyo"), class: "block rounded-sm mb-4 w-[20rem]" %>
+  <%= f.datetime_field :start_at, value: @signage_schedule.start_at.in_time_zone("Tokyo"), class: "block rounded-sm border-1 border-gray-400 mb-4 w-[20rem]" %>
   <%= f.label :end_at, "終了時刻", class: "block text-lg font-bold mb-2" %>
-  <%= f.datetime_field :end_at, value: @signage_schedule.end_at.in_time_zone("Tokyo"), class: "block rounded-sm mb-4 w-[20rem]" %>
+  <%= f.datetime_field :end_at, value: @signage_schedule.end_at.in_time_zone("Tokyo"), class: "block rounded-sm border-1 border-gray-400 mb-4 w-[20rem]" %>
   <%= f.submit "Update", class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
 <% end %>

--- a/app/views/admin/signage_schedules/new.html.erb
+++ b/app/views/admin/signage_schedules/new.html.erb
@@ -1,8 +1,8 @@
 <h2 class="font-bold text-xl mb-8">New Signage schedule</h2>
 <%= form_with model: @signage_schedule, url: admin_signage_schedules_path, method: :post do |f| %>
   <%= f.label :start_at, "開始時刻", class: "block text-lg font-bold mb-2" %>
-  <%= f.datetime_field :start_at, class: "block rounded-sm mb-4 w-[20rem]" %>
+  <%= f.datetime_field :start_at, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[20rem]" %>
   <%= f.label :end_at, "終了時刻", class: "block text-lg font-bold mb-2" %>
-  <%= f.datetime_field :end_at, class: "block rounded-sm mb-4 w-[20rem]" %>
+  <%= f.datetime_field :end_at, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[20rem]" %>
   <%= f.submit "Create", class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
 <% end %>

--- a/app/views/admin/talks/edit.html.erb
+++ b/app/views/admin/talks/edit.html.erb
@@ -2,17 +2,17 @@
 <div>
   <%= form_with model: @talk, url: admin_talk_path(@talk) do |f| %>
     <%= f.label :title, "Title", class: "block text-lg font-bold mb-2" %>
-    <%= f.text_field :title, class: "block rounded-sm mb-4 w-[40rem]" %>
+    <%= f.text_field :title, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[40rem]" %>
     <%= f.label :abstract, "Abstract", class: "block text-lg font-bold mb-2" %>
-    <%= f.text_area :abstract, size: "100x20", class: "block rounded-sm mb-4" %>
+    <%= f.text_area :abstract, size: "100x20", class: "block rounded-sm border-1 border-gray-400 mb-4" %>
     <%= f.label :start_at_date, "Start at (date)", class: "block text-lg font-bold mb-2" %>
-    <%= f.date_field :start_at_date, value: @talk.start_at.to_date, class: "block rounded-sm mb-4" %>
+    <%= f.date_field :start_at_date, value: @talk.start_at.to_date, class: "block rounded-sm border-1 border-gray-400 mb-4" %>
     <%= f.label :start_at_time, "Start at (time, in JST)", class: "block text-lg font-bold mb-2" %>
-    <%= f.time_field :start_at_time, value: @talk.start_at.in_time_zone("Tokyo").strftime("%H:%M"), class: "block rounded-sm mb-4" %>
+    <%= f.time_field :start_at_time, value: @talk.start_at.in_time_zone("Tokyo").strftime("%H:%M"), class: "block rounded-sm border-1 border-gray-400 mb-4" %>
     <%= f.label :track, "Track", class: "block text-lg font-bold mb-2" %>
-    <%= f.text_field :track, class: "block rounded-sm mb-4" %>
+    <%= f.text_field :track, class: "block rounded-sm border-1 border-gray-400 mb-4" %>
     <%= f.label :duration_minutes, "Duration (minutes)", class: "block text-lg font-bold mb-2" %>
-    <%= f.number_field :duration_minutes, class: "block rounded-sm mb-8" %>
+    <%= f.number_field :duration_minutes, class: "block rounded-sm border-1 border-gray-400 mb-8" %>
     <%= f.submit class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
   <% end %>
 </div>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -2,7 +2,7 @@
 <div>
   <%= form_with model: @user, url: admin_user_path(@user) do |f| %>
     <%= f.label :role, "Role", class: "block text-lg font-bold mb-2" %>
-    <%= f.select :role, User.roles, {}, class: "block rounded-sm border-1 mb-20" %>
+    <%= f.select :role, User.roles, {}, class: "block rounded-sm border-1 border-gray-400 mb-20" %>
     <%= f.submit class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
   <% end %>
 </div>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -3,16 +3,16 @@
   <div class="mb-8">
     <%= form_with model: @user, url: admin_users_path do |f| %>
       <%= f.label :name, "Name (recommend: use email for ensure uniqueness)", requierd: true, class: "block text-lg font-bold mb-2" %>
-      <%= f.text_field :name, class: "block rounded-sm mb-4 w-[20rem]" %>
+      <%= f.text_field :name, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[20rem]" %>
       <%= f.label :role, "Role (operator)", class: "block text-lg font-bold mb-2" %>
-      <%= f.text_field :role, value: "operator", readonly: true, class: "block rounded-sm mb-4 w-[20rem]" %>
+      <%= f.text_field :role, value: "operator", readonly: true, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[20rem]" %>
       <%= fields_for :auth, @user.authentication_provider_email_and_password do |auth_field| %>
         <%= auth_field.label :email, "email address uses for login (recommend: same as name)", class: "block text-lg font-bold mb-2" %>
-        <%= auth_field.email_field :email, class: "block rounded-sm mb-4 w-[20rem]", requierd: true %>
+        <%= auth_field.email_field :email, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[20rem]", requierd: true %>
         <%= auth_field.label :password, "password", class: "block text-lg font-bold mb-2" %>
-        <%= auth_field.password_field :password, class: "block rounded-sm mb-4 w-[20rem]" %>
+        <%= auth_field.password_field :password, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[20rem]" %>
         <%= auth_field.label :password_confirmation, "password (confirmation)", class: "block text-lg font-bold mb-2" %>
-        <%= auth_field.password_field :password_confirmation, class: "block rounded-sm mb-4 w-[20rem]" %>
+        <%= auth_field.password_field :password_confirmation, class: "block rounded-sm border-1 border-gray-400 mb-4 w-[20rem]" %>
       <% end %>
       <%= f.submit class: "block border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
     <% end %>


### PR DESCRIPTION
Tailwind v4's preflight resets border-width to 0 on every element, so admin inputs that only specified "block rounded-sm ..." lost the browser's default border too. With a transparent background there was nothing left to indicate where the input actually was.

The v3 compatibility layer in app/assets/tailwind/application.css already sets border-color to gray-200 globally, so only the width was missing -- but gray-200 is too faint on a white background, so the color is specified explicitly as well.

- border-1 border-gray-400 is inserted right after rounded-sm, the order the two pre-existing border-1 usages already followed
- border-1 over border for the same reason; they are equivalent in Tailwind v4
- rich_text_area, color_field, check_box and file_field are left alone: they keep a visible native UI even without a border