### PR TITLE
fix broken cache-control on static files

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,19 +19,10 @@ Rails.application.configure do
   # Turn on fragment caching in view templates.
   config.action_controller.perform_caching = true
 
-  # Cache digest stamped assets for far-future expiry.
-  # Short cache for others: robots.txt, sitemap.xml, 404.html, etc.
+  # Short common cache for all static files: public/ holds non-fingerprinted
+  # files (robots.txt, error pages) and per-path values are not supported.
   config.public_file_server.headers = {
-    "cache-control" => lambda do |path, _|
-      if path.start_with?("/assets/")
-        # Files in /assets/ are expected to be fully immutable.
-        # If the content change the URL too.
-        "public, immutable, max-age=#{1.year.to_i}"
-      else
-        # For anything else we cache for 1 minute.
-        "public, max-age=#{1.minute.to_i}, stale-while-revalidate=#{5.minutes.to_i}"
-      end
-    end
+    "cache-control" => "public, max-age=#{1.hour.to_i}, stale-while-revalidate=#{5.minutes.to_i}"
   }
 
   config.assets.compile = false


### PR DESCRIPTION
## What

`config.public_file_server.headers` contained a lambda taken from the Rails 8.1.0.beta1 template via bin/rails app:update (eef74aa), but `Rack::Files` never calls callables in the headers hash, so responses carried a `Proc#to_s` as cache-control and browsers cached nothing. Rails reverted the template default in `rails/rails#55633`.

Replace it with a fixed string as the revert instructs, using 1 hour + stale-while-revalidate instead of the default 1 year: public/ also serves non-fingerprinted files (robots.txt, error pages) that must stay replaceable, and per-path values are not possible without callable support.