### PR TITLE
admin/social_announcements: toast feedback on saves

### DIFF
--- a/app/controllers/admin/social_announcement_media_controller.rb
+++ b/app/controllers/admin/social_announcement_media_controller.rb
@@ -14,18 +14,16 @@ class Admin::SocialAnnouncementMediaController < AdminController
     redirect_to admin_social_announcement_path(announcement)
   end
 
-  # alt text と並び順の更新。カードは Turbo Frame で、成功時のリダイレクトは自カードだけ
-  # 差し替えるため、他の入力欄の内容は消えない。失敗時はエラー付きカードを 422 で返す
+  # alt text と並び順の更新。カードは Turbo Frame で、成功時は自カードの差し替えと保存トーストを
+  # Turbo Stream で返すため、他の入力欄の内容は消えない。失敗時はエラー付きカードを 422 で返す
   # @rbs return: void
   def update
     announcement = SocialAnnouncement.find(params[:social_announcement_id])
     medium = announcement.media.find(params[:id])
     if medium.update(**media_params.slice(:alt_text_ja, :alt_text_en, :position))
-      redirect_to admin_social_announcement_path(announcement)
+      render_saved announcement, medium
     else
-      render partial: "admin/social_announcements/media_card",
-        locals: {announcement: announcement, medium: medium, published: announcement.published_at.present?, errors: medium.errors.full_messages},
-        status: :unprocessable_content
+      render_card announcement, medium, medium.errors.full_messages
     end
   end
 
@@ -40,5 +38,35 @@ class Admin::SocialAnnouncementMediaController < AdminController
 
   private def media_params
     params.require(:social_announcement_media).permit(:file, :alt_text_ja, :alt_text_en, :position)
+  end
+
+  # @rbs announcement: SocialAnnouncement
+  # @rbs medium: SocialAnnouncementMedia
+  # @rbs return: void
+  private def render_saved(announcement, medium)
+    no_errors = [] #: Array[String]
+    respond_to do |format|
+      format.html { redirect_to admin_social_announcement_path(announcement) }
+      format.turbo_stream do
+        render turbo_stream: [
+          turbo_stream.replace("social_announcement_medium_#{medium.id}",
+            partial: "admin/social_announcements/media_card",
+            locals: {announcement: announcement, medium: medium, published: announcement.published_at.present?, errors: no_errors}),
+          turbo_stream.append("toasts",
+            partial: "admin/social_announcements/toast",
+            locals: {type: :success, message: "Media ##{medium.id} updated"})
+        ]
+      end
+    end
+  end
+
+  # @rbs announcement: SocialAnnouncement
+  # @rbs medium: SocialAnnouncementMedia
+  # @rbs errors: Array[String]
+  # @rbs return: void
+  private def render_card(announcement, medium, errors)
+    render partial: "admin/social_announcements/media_card",
+      locals: {announcement: announcement, medium: medium, published: announcement.published_at.present?, errors: errors},
+      status: :unprocessable_content
   end
 end

--- a/app/controllers/admin/social_announcement_texts_controller.rb
+++ b/app/controllers/admin/social_announcement_texts_controller.rb
@@ -1,5 +1,5 @@
 class Admin::SocialAnnouncementTextsController < AdminController
-  # 各言語カラムは Turbo Frame。成功時のリダイレクトでは frame が自カラムだけ差し替えるので、
+  # 各言語カラムは Turbo Frame。成功時は自カラムの差し替えと保存トーストを Turbo Stream で返すので、
   # もう片方のカラムで入力中の内容は消えない。失敗時はエラー付きのカラムを 422 で返す。
 
   # @rbs return: void
@@ -7,7 +7,7 @@ class Admin::SocialAnnouncementTextsController < AdminController
     announcement = SocialAnnouncement.find(params[:social_announcement_id])
     text = announcement.texts.build(locale: text_params[:locale], body: text_params[:body])
     if text.save
-      redirect_to admin_social_announcement_path(announcement)
+      render_saved announcement, text
     else
       render_column announcement, text
     end
@@ -18,7 +18,7 @@ class Admin::SocialAnnouncementTextsController < AdminController
     announcement = SocialAnnouncement.find(params[:social_announcement_id])
     text = announcement.texts.find(params[:id])
     if text.update(body: text_params[:body])
-      redirect_to admin_social_announcement_path(announcement)
+      render_saved announcement, text
     else
       render_column announcement, text
     end
@@ -26,6 +26,26 @@ class Admin::SocialAnnouncementTextsController < AdminController
 
   private def text_params
     params.require(:social_announcement_text).permit(:locale, :body)
+  end
+
+  # @rbs announcement: SocialAnnouncement
+  # @rbs text: SocialAnnouncementText
+  # @rbs return: void
+  private def render_saved(announcement, text)
+    no_errors = [] #: Array[String]
+    respond_to do |format|
+      format.html { redirect_to admin_social_announcement_path(announcement) }
+      format.turbo_stream do
+        render turbo_stream: [
+          turbo_stream.replace("social_announcement_text_#{text.locale}",
+            partial: "admin/social_announcements/text_column",
+            locals: {announcement: announcement, locale: text.locale, text: text, errors: no_errors}),
+          turbo_stream.append("toasts",
+            partial: "admin/social_announcements/toast",
+            locals: {type: :success, message: "Text (#{text.locale}) saved"})
+        ]
+      end
+    end
   end
 
   # @rbs announcement: SocialAnnouncement

--- a/app/javascript/controllers/admin/toast_controller.js
+++ b/app/javascript/controllers/admin/toast_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus";
+
+// トーストを duration ミリ秒後に自動で閉じる。duration が 0 ならクリックされるまで残す。
+const FADE_OUT_MS = 300;
+
+export default class extends Controller {
+  static values = { duration: { type: Number, default: 5000 } };
+
+  connect() {
+    if (this.durationValue > 0) {
+      this.timer = setTimeout(() => this.dismiss(), this.durationValue);
+    }
+  }
+
+  disconnect() {
+    clearTimeout(this.timer);
+  }
+
+  dismiss() {
+    clearTimeout(this.timer);
+    // opacity-0 クラスは ERB に現れず Tailwind が生成しないので style で消す
+    this.element.style.opacity = "0";
+    setTimeout(() => this.element.remove(), FADE_OUT_MS);
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,6 +13,7 @@ import TalkBookmarksController from "./talk_bookmarks_controller";
 import UsersController from "./users_controller";
 import AdminProfileBadgeController from "./admin/profile_badge_controller";
 import AdminSocialAnnouncementController from "./admin/social_announcement_controller";
+import AdminToastController from "./admin/toast_controller";
 
 application.register("announcements", AnnouncementsController);
 application.register("live-streams", LiveStreamsController);
@@ -27,3 +28,4 @@ application.register("talk-bookmarks", TalkBookmarksController);
 application.register("users", UsersController);
 application.register("admin--profile-badge", AdminProfileBadgeController);
 application.register("admin--social-announcement", AdminSocialAnnouncementController);
+application.register("admin--toast", AdminToastController);

--- a/app/views/admin/social_announcements/_flash.html.erb
+++ b/app/views/admin/social_announcements/_flash.html.erb
@@ -1,5 +1,6 @@
-<% flash.each do |message_type, message| %>
-  <div class="py-3 px-5 mb-4 mr-8 border rounded-sm <%= (message_type.to_s == "alert") ? "bg-red-50 border-red-300" : "bg-green-50 border-green-300" %>">
-    <%= message %>
-  </div>
-<% end %>
+<%# flash も Turbo Stream 経由の保存通知 (turbo_stream.append "toasts") も同じコンテナに積む %>
+<div id="toasts" class="fixed bottom-4 right-4 z-50 flex flex-col items-end gap-2">
+  <% flash.each do |message_type, message| %>
+    <%= render "admin/social_announcements/toast", type: message_type, message: message %>
+  <% end %>
+</div>

--- a/app/views/admin/social_announcements/_toast.html.erb
+++ b/app/views/admin/social_announcements/_toast.html.erb
@@ -1,0 +1,10 @@
+<%# locals: (type:, message:) %>
+<% alert = type.to_s == "alert" %>
+<%# alert は消えると原因を追えないのでクリックするまで残す (duration 0) %>
+<div class="flex items-start gap-3 max-w-sm py-3 px-5 border rounded-sm shadow-lg transition-opacity duration-300 <%= alert ? "bg-red-50 border-red-300" : "bg-green-50 border-green-300" %>"
+  role="status"
+  data-controller="admin--toast"
+  data-admin--toast-duration-value="<%= alert ? 0 : 5000 %>">
+  <span><%= message %></span>
+  <button type="button" class="font-bold text-gray-500 cursor-pointer" aria-label="close" data-action="admin--toast#dismiss">×</button>
+</div>

--- a/sig/generated/controllers/admin/social_announcement_media_controller.rbs
+++ b/sig/generated/controllers/admin/social_announcement_media_controller.rbs
@@ -4,7 +4,8 @@ class Admin::SocialAnnouncementMediaController < AdminController
   # @rbs return: void
   def create: () -> void
 
-  # alt text と並び順の更新
+  # alt text と並び順の更新。カードは Turbo Frame で、成功時は自カードの差し替えと保存トーストを
+  # Turbo Stream で返すため、他の入力欄の内容は消えない。失敗時はエラー付きカードを 422 で返す
   # @rbs return: void
   def update: () -> void
 
@@ -12,4 +13,15 @@ class Admin::SocialAnnouncementMediaController < AdminController
   def destroy: () -> void
 
   private def media_params: () -> untyped
+
+  # @rbs announcement: SocialAnnouncement
+  # @rbs medium: SocialAnnouncementMedia
+  # @rbs return: void
+  private def render_saved: (SocialAnnouncement announcement, SocialAnnouncementMedia medium) -> void
+
+  # @rbs announcement: SocialAnnouncement
+  # @rbs medium: SocialAnnouncementMedia
+  # @rbs errors: Array[String]
+  # @rbs return: void
+  private def render_card: (SocialAnnouncement announcement, SocialAnnouncementMedia medium, Array[String] errors) -> void
 end

--- a/sig/generated/controllers/admin/social_announcement_texts_controller.rbs
+++ b/sig/generated/controllers/admin/social_announcement_texts_controller.rbs
@@ -12,5 +12,10 @@ class Admin::SocialAnnouncementTextsController < AdminController
   # @rbs announcement: SocialAnnouncement
   # @rbs text: SocialAnnouncementText
   # @rbs return: void
+  private def render_saved: (SocialAnnouncement announcement, SocialAnnouncementText text) -> void
+
+  # @rbs announcement: SocialAnnouncement
+  # @rbs text: SocialAnnouncementText
+  # @rbs return: void
   private def render_column: (SocialAnnouncement announcement, SocialAnnouncementText text) -> void
 end

--- a/sig/handwritten/gems/turbo.rbs
+++ b/sig/handwritten/gems/turbo.rbs
@@ -1,0 +1,5 @@
+# turbo-rails が ActionController::Base に mixin する turbo_stream ヘルパ。
+# gem に RBS が同梱されていないため手書きで補う。
+class ActionController::Base
+  def turbo_stream: () -> untyped
+end

--- a/spec/requests/admin/social_announcements_spec.rb
+++ b/spec/requests/admin/social_announcements_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe "Admin::SocialAnnouncements", type: :request do
   let(:admin) { FactoryBot.create(:user, role: "organizer") }
   let!(:event) { FactoryBot.create(:event, slug: Event::ONGOING_EVENT_SLUG) }
 
+  let(:turbo_stream_headers) { {"Accept" => "text/vnd.turbo-stream.html, text/html"} }
+
   before { sign_in(admin) }
 
   it "rejects non-organizers" do
@@ -95,6 +97,14 @@ RSpec.describe "Admin::SocialAnnouncements", type: :request do
       expect(text.reload.body).to eq("改稿")
     end
 
+    it "replaces the column and appends a toast on a Turbo Stream save" do
+      post admin_social_announcement_texts_path(announcement), params: {social_announcement_text: {locale: "ja", body: "初稿"}}, headers: turbo_stream_headers
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include("social_announcement_text_ja")
+      expect(response.body).to include(%(target="toasts"))
+      expect(response.body).to include("Text (ja) saved")
+    end
+
     it "rejects over-limit body and re-renders the column with the error" do
       post admin_social_announcement_texts_path(announcement), params: {social_announcement_text: {locale: "ja", body: "あ" * 141}}
       expect(announcement.texts.count).to eq(0)
@@ -180,6 +190,15 @@ RSpec.describe "Admin::SocialAnnouncements", type: :request do
 
       delete admin_social_announcement_medium_path(announcement, medium)
       expect(announcement.media.count).to eq(0)
+    end
+
+    it "replaces the card and appends a toast on a Turbo Stream update" do
+      medium = FactoryBot.create(:social_announcement_media, social_announcement: announcement)
+      patch admin_social_announcement_medium_path(announcement, medium), params: {social_announcement_media: {alt_text_ja: "new alt"}}, headers: turbo_stream_headers
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include("social_announcement_medium_#{medium.id}")
+      expect(response.body).to include(%(target="toasts"))
+      expect(response.body).to include("Media ##{medium.id} updated")
     end
 
     it "re-renders the media card with the error when alt text is invalid" do


### PR DESCRIPTION
## What

Saving a text or media inside a Turbo Frame only swapped the frame, so there was no sign on screen whether the save had succeeded. Respond with a Turbo Stream that replaces the frame and appends to #toasts, showing a toast in the bottom right corner.

Rewrite _flash to stack flash messages into the same #toasts container so the feedback for full page navigations looks the same. A success toast disappears after 5 seconds; an alert stays until clicked, since its cause is lost once it is gone.

The format.html redirect is kept for requests made without Turbo.

## screen record

https://github.com/user-attachments/assets/e3860914-8da2-4a50-9edc-691892b5542d

