### PR TITLE
feat: add role filter to admin users index

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,7 +4,9 @@ class Admin::UsersController < AdminController
 
   # @rbs return: void
   def index
-    @users = User.eager_load(:profile).order(created_at: :asc).page(params[:page])
+    scope = User.eager_load(:profile)
+    scope = scope.where(role: params[:role]) if User.roles.key?(params[:role])
+    @users = scope.order(created_at: :asc).page(params[:page])
   end
 
   # @rbs return: void

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,5 @@
+module Admin::UsersHelper
+  def user_role_options
+    User.roles.keys.map { |role| [role.humanize, role] }
+  end
+end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,4 +1,8 @@
 <h2 class="font-bold text-xl mb-8">Users</h2>
+<%= form_with url: admin_users_path, method: :get, class: "flex items-center gap-2 mb-8" do |f| %>
+  <%= f.label :role, "Role" %>
+  <%= f.select :role, user_role_options, {include_blank: "All", selected: params[:role]}, class: "rounded-sm border-1 border-gray-400", onchange: "this.form.requestSubmit()" %>
+<% end %>
 <div class="rounded-sm w-full pr-8 shadow-xs">
   <table class="w-full divide-y border">
     <thead class="bg-gray-50">

--- a/sig/handwritten/app/helpers/admin/users_helper.rbs
+++ b/sig/handwritten/app/helpers/admin/users_helper.rbs
@@ -1,0 +1,3 @@
+module Admin::UsersHelper
+  def user_role_options: () -> Array[Array[String]]
+end

--- a/sig/handwritten/app/models/user.rbs
+++ b/sig/handwritten/app/models/user.rbs
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   # NOTE: This method has been declared manually because current rbs_rails does not support enum definitions.
   #       It should be removed if rbs_rails will support it.
   #       refs: https://github.com/pocke/rbs_rails/pull/268
+  def self.roles: () -> Hash[String, String]
+
   def organizer?: () -> bool
   def participant?: () -> bool
   def operator?: () -> bool

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe "Admin::Users", type: :request do
         expect(response.body).to include("Users")
         expect(response.body).to include("sample_user_1")
       end
+
+      it "filters users by role" do
+        FactoryBot.create(:user, role: :organizer, name: "filtered_organizer")
+        FactoryBot.create(:user, role: :operator, name: "filtered_operator")
+
+        get admin_users_path, params: {role: "operator"}
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("filtered_operator")
+        expect(response.body).not_to include("filtered_organizer")
+        expect(response.body).not_to include("sample_user_1")
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Add a role filter to the admin users index to make reviewing and auditing administrator accounts easier.

before | after 
--- | ---
<img width="429" height="339" alt="スクリーンショット 2026-09-12 17 16 45" src="https://github.com/user-attachments/assets/a72e4f48-6aa1-4c3d-93b5-188c08f8b3ad" /> | <img width="433" height="402" alt="スクリーンショット 2026-09-12 17 16 05" src="https://github.com/user-attachments/assets/6b72aafb-2d7e-468c-979d-0478a0df293a" />

## Changes

- Add filtering by `organizer`, `participant`, and `operator`
  <img width="436" height="297" alt="スクリーンショット 2026-09-12 17 16 23" src="https://github.com/user-attachments/assets/ed7e64db-b14c-4d44-a990-865f6189d602" />
- Add an `All` option to show all users
- Submit the filter using GET parameters
- Ignore invalid role values and show all users
- Move role option generation from the view to `Admin::UsersHelper`
- Add RBS definitions for `User.roles` and the new helper method

## Testing

- `bundle exec rspec spec/requests/admin/users_spec.rb`
- 9 examples, 0 failures
- `bundle exec steep check`
- `rbs validate`