### PR TITLE
Add name prefix search to admin users

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -6,6 +6,7 @@ class Admin::UsersController < AdminController
   def index
     scope = User.eager_load(:profile)
     scope = scope.where(role: params[:role]) if User.roles.key?(params[:role])
+    scope = scope.name_starts_with(params[:name].to_s) if params[:name].present?
     @users = scope.order(created_at: :asc).page(params[:page])
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,10 @@ class User < ApplicationRecord
 
   enum :role, {organizer: "organizer", participant: "participant", operator: "operator"}
 
+  scope :name_starts_with, ->(name) {
+    where("users.name ILIKE ?", "#{sanitize_sql_like(name.strip)}%")
+  }
+
   # @rbs return: bool
   def have_unread_announcements?
     unread_announcement_count > 0

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,8 +1,17 @@
 <h2 class="font-bold text-xl mb-8">Users</h2>
-<%= form_with url: admin_users_path, method: :get, class: "flex items-center gap-2 mb-8" do |f| %>
-  <%= f.label :role, "Role" %>
-  <%= f.select :role, user_role_options, {include_blank: "All", selected: params[:role]}, class: "rounded-sm border-1 border-gray-400", onchange: "this.form.requestSubmit()" %>
-<% end %>
+<div class="flex flex-wrap items-center gap-8 mb-8">
+  <%= form_with url: admin_users_path, method: :get, class: "flex items-center gap-2" do |f| %>
+    <%= f.hidden_field :role, value: params[:role], id: nil %>
+    <%= f.label :name, "Name" %>
+    <%= f.search_field :name, value: params[:name], class: "rounded-sm border-1 border-gray-400" %>
+    <%= f.submit "Search", class: "border shadow-sm border-gray-500 rounded-sm px-4 py-2 cursor-pointer" %>
+  <% end %>
+  <%= form_with url: admin_users_path, method: :get, class: "flex items-center gap-2" do |f| %>
+    <%= f.hidden_field :name, value: params[:name], id: nil %>
+    <%= f.label :role, "Role" %>
+    <%= f.select :role, user_role_options, {include_blank: "All", selected: params[:role]}, class: "rounded-sm border-1 border-gray-400", onchange: "this.form.requestSubmit()" %>
+  <% end %>
+</div>
 <div class="rounded-sm w-full pr-8 shadow-xs">
   <table class="w-full divide-y border">
     <thead class="bg-gray-50">

--- a/sig/handwritten/app/models/user.rbs
+++ b/sig/handwritten/app/models/user.rbs
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   #       refs: https://github.com/pocke/rbs_rails/pull/268
   def self.roles: () -> Hash[String, String]
 
+  def self.name_starts_with: (String name) -> User::ActiveRecord_Relation
+
   def organizer?: () -> bool
   def participant?: () -> bool
   def operator?: () -> bool
@@ -15,6 +17,8 @@ class User < ApplicationRecord
                                     | ...
 
   class ActiveRecord_Relation
+    def name_starts_with: (String name) -> User::ActiveRecord_Relation
+
     # NOTE: Added by kaminari
     def page: (untyped) -> self
     def per: (Integer) -> self

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,74 @@ require "rails_helper"
 RSpec.describe User, type: :model do
   let(:user) { FactoryBot.create(:user) }
 
+  describe ".name_starts_with" do
+    context "with exact, prefix, and non-prefix matches" do
+      let!(:exact) { FactoryBot.create(:user, name: "alice") }
+      let!(:prefixed) { FactoryBot.create(:user, name: "alice_smith") }
+
+      before do
+        FactoryBot.create(:user, name: "malice")
+        FactoryBot.create(:user, name: "bob")
+      end
+
+      it "matches names starting with the prefix, including an exact match" do
+        expect(User.name_starts_with("alice")).to contain_exactly(exact, prefixed)
+      end
+    end
+
+    context "with different letter cases" do
+      let!(:matching) { FactoryBot.create(:user, name: "Alice") }
+
+      it "ignores case" do
+        expect(User.name_starts_with("ALi")).to contain_exactly(matching)
+      end
+    end
+
+    context "with surrounding whitespace" do
+      let!(:matching) { FactoryBot.create(:user, name: "alice") }
+
+      it "strips surrounding whitespace from the prefix" do
+        expect(User.name_starts_with("  ali  ")).to contain_exactly(matching)
+      end
+    end
+
+    context "with a percent sign in the prefix" do
+      let!(:matching) { FactoryBot.create(:user, name: "ali%ce") }
+
+      before do
+        FactoryBot.create(:user, name: "alice")
+      end
+
+      it "treats percent signs as literal characters" do
+        expect(User.name_starts_with("ali%")).to contain_exactly(matching)
+      end
+    end
+
+    context "with an underscore in the prefix" do
+      let!(:matching) { FactoryBot.create(:user, name: "ali_ce") }
+
+      before do
+        FactoryBot.create(:user, name: "alice")
+      end
+
+      it "treats underscores as literal characters" do
+        expect(User.name_starts_with("ali_")).to contain_exactly(matching)
+      end
+    end
+
+    context "with an existing role condition" do
+      let!(:matching) { FactoryBot.create(:user, name: "alice", role: :operator) }
+
+      before do
+        FactoryBot.create(:user, name: "alice_smith", role: :participant)
+      end
+
+      it "preserves other filtering conditions" do
+        expect(User.where(role: :operator).name_starts_with("ali")).to contain_exactly(matching)
+      end
+    end
+  end
+
   describe "#mark_all_announcement_unread!" do
     context "there is no published announcement" do
       let(:event) { FactoryBot.create(:event) }

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -27,16 +27,93 @@ RSpec.describe "Admin::Users", type: :request do
         expect(response.body).to include("sample_user_1")
       end
 
-      it "filters users by role" do
-        FactoryBot.create(:user, role: :organizer, name: "filtered_organizer")
-        FactoryBot.create(:user, role: :operator, name: "filtered_operator")
+      context "with a role filter" do
+        before do
+          FactoryBot.create(:user, role: :organizer, name: "filtered_organizer")
+          FactoryBot.create(:user, role: :operator, name: "filtered_operator")
+        end
 
-        get admin_users_path, params: {role: "operator"}
+        it "filters users by role" do
+          get admin_users_path, params: {role: "operator"}
 
-        expect(response).to have_http_status(:success)
-        expect(response.body).to include("filtered_operator")
-        expect(response.body).not_to include("filtered_organizer")
-        expect(response.body).not_to include("sample_user_1")
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include("filtered_operator")
+          expect(response.body).not_to include("filtered_organizer")
+          expect(response.body).not_to include("sample_user_1")
+        end
+      end
+
+      context "with a name filter" do
+        before do
+          FactoryBot.create(:user, name: "other_user")
+        end
+
+        it "filters users by name prefix" do
+          get admin_users_path, params: {name: "sample_user"}
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include("sample_user_1")
+          expect(response.body).to include("sample_user_2")
+          expect(response.body).to include("sample_user_3")
+          expect(response.body).not_to include("other_user")
+        end
+      end
+
+      context "with name and role filters" do
+        before do
+          FactoryBot.create(:user, name: "sample_operator", role: :operator)
+          FactoryBot.create(:user, name: "other_operator", role: :operator)
+        end
+
+        it "filters users by both name and role" do
+          get admin_users_path, params: {name: "sample", role: "operator"}
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include("sample_operator")
+          expect(response.body).not_to include("sample_user_1", "other_operator")
+        end
+      end
+
+      context "with an invalid role" do
+        before do
+          FactoryBot.create(:user, name: "listed_organizer", role: :organizer)
+          FactoryBot.create(:user, name: "listed_operator", role: :operator)
+        end
+
+        it "shows the normal user list for an invalid role" do
+          get admin_users_path, params: {role: "invalid"}
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include("sample_user_1", "sample_user_2", "sample_user_3", "listed_organizer", "listed_operator")
+        end
+      end
+
+      context "with a name filter and an invalid role" do
+        before do
+          FactoryBot.create(:user, name: "other_user")
+        end
+
+        it "still filters by name when the role is invalid" do
+          get admin_users_path, params: {name: "sample", role: "invalid"}
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include("sample_user_1")
+          expect(response.body).not_to include("other_user")
+        end
+      end
+
+      context "with an empty name and a role filter" do
+        before do
+          FactoryBot.create(:user, name: "listed_operator", role: :operator)
+        end
+
+        it "keeps the role filter when the name search is cleared" do
+          get admin_users_path, params: {name: "", role: "operator"}
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include("listed_operator")
+          expect(response.body).not_to include("sample_user_1")
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Make it easier to find users, primarily when changing their roles, by adding case-insensitive name prefix search to the admin users page.

Name searches are applied using Search or Enter. Role filters continue to apply immediately on selection. Each form preserves the other applied filter, so changing the role does not submit an unfinished name search.


https://github.com/user-attachments/assets/28648319-c569-41d3-af98-a4e119517eec


## Changes

- Add a `User.name_starts_with` scope that trims surrounding whitespace and treats SQL wildcard characters as literal input.
- Place the Search button next to the Name field and separate the name and role forms.
- Add RBS declarations for the scope.
- Add model specs for prefix matching, case insensitivity, whitespace trimming, escaping, and scope chaining.
- Add request specs for combined filters, invalid roles, and clearing the name search.
- Follow existing test setup conventions using `before` and `let!`, including in the existing role-filter spec.

## Validation

- Model and request specs: 28 examples, 0 failures
- Steep: no type errors